### PR TITLE
Generate loadresources

### DIFF
--- a/generate/README.md
+++ b/generate/README.md
@@ -153,6 +153,15 @@ There may be differences for xis and phr scenarios in how a TestScript is transf
 nts:scenario="server|client"
 ```
 
+### TouchStone stopTestOnFail extension
+The TouchStone assert-stopTestOnFail extension is added to each assert with a default value of 'false' (e.g. the test continues running after a failed assertion). If you would like to override this value, add attribute `@nts:stopTestOnFail="true"` to `<assert>`.
+
+```xml
+<assert nts:stopTestOnFail="true">
+    ...
+</assert>
+```
+
 ## Running the transformation
 
 The transformation is called by the ANT build in `ant/build.xml`. For more information on the location of the inputs and outputs, see [the readme in the TestScripts repository](https://github.com/Nictiz/Nictiz-STU3-testscripts/blob/master/Generate/README.md).
@@ -217,6 +226,7 @@ Because of the verbosity of the ANT build, the logging level is set to 1 (warnin
 
 ### 1.2.0
 - A LoadResources script is now generated for a project
+- TouchStone stopTestOnFail extension is added to each assert
 
 ### 1.1.4
 - Fixed a bug where an attribute in a non nts-namespace (for example `@xsi:*`) caused the process to crash.

--- a/generate/README.md
+++ b/generate/README.md
@@ -112,6 +112,8 @@ Fixtures and rules can be defined using:
 
 `href` is considered to be relative to a predefined fixtures folder. It defaults to the "_reference" folder directly beneath the project-folder. See the section on building to set an alternate location. All fixtures and rules in the "_reference"-folder are copied to the output folder.
 
+A LoadResources script is generated for all fixtures in the "_reference"-folder. See the section on building on how to exclude files and/or folders from being added the LoadResources script. 
+
 Profiles may be defined using:
 
 ```xml
@@ -132,6 +134,8 @@ The `href` attribute should point to the `Patient` instance containing the token
 
 * for "server", a variable will be created which the test script executor can set, defaulting to the value from the fixture.
 * for "client", the fixture will be included and a variable called "patient-token-id" will be created that reads the value from the fixture
+
+The token filename should end with `token.xml` and the token id should start with `Bearer`.
 
 The second element is to indicate that the "date T" variable should be defined for the testscript:
 
@@ -194,6 +198,11 @@ The build script recognizes several parameters:
 - `-Dcommoncomponents.dir=/path/to/common/components`: An alternative location for common NTS components. Should be an absolute or relative path, compared to `build.xml`.
 - `-Dcomponents.dir=/path/to/project/components`: An alternative location for project specific NTS components. Should be an absolute or relative path, compared to `build.xml`.
 
+To exclude fixtures from being added to the LoadResources script, add a `build.properties` file to the project root, with the `loadresources.exclude` key set to a relative path to a folder containing the fixtures to be excluded or to specific filenames. Multiple entries can be comma separated.
+```
+loadresources.exclude = _reference/resources/resources-specific
+```
+
 ## Schematron
 
 A schematron is available that can be used to check both the input TestScript files and the component files. It is reasonably complete and covers everything on the root level of the input files.
@@ -205,6 +214,9 @@ It can be found at `schematron/NictizTestScript.sch` relative to this README.
 Because of the verbosity of the ANT build, the logging level is set to 1 (warning) and Saxon is set to not try to recover. When more verbose output is wanted, the logging level can be changed by setting the `-DoutputLevel=` parameter on the ANT build.
 
 ## Changelog
+
+### 1.2.0
+- A LoadResources script is now generated for a project
 
 ### 1.1.4
 - Fixed a bug where an attribute in a non nts-namespace (for example `@xsi:*`) caused the process to crash.

--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -19,6 +19,7 @@
 -->
 
 <project xmlns:ivy="antlib:org.apache.ivy.ant" basedir="." name="generateTestScripts" default="build">
+    
     <!-- Set testscripttools.dir if it is not supplied by including build file. -->
     <dirname property="testscripttools.dir" file="${ant.file.generateTestScripts}/.."/>
     
@@ -284,6 +285,7 @@
                     <param name="referenceBase" expression="${reference.dir.loadresourcesrelative.normalized}"/>
                     <param name="referenceDir" expression="${project.dir}/_reference/"/>
                     <param name="project" expression="${project}"/>
+                    <param name="loadResourcesExclude" expression="${loadresources.exclude}"/>
                 </parameters>
             </saxon-transform>
         </sequential>
@@ -298,6 +300,9 @@
     
     <target name="build" depends="load, check-input, cleanBuildDir">
         <property name="project.dir" location="${src.dir}/${project}"/>
+        
+        <property file="${project.dir}/build.properties"/>
+        
         <property name="commoncomponents.dir" location="${src.dir}/common-asserts"/>
         <property name="reference.dir" location="${project.dir}/_reference"/>
         <property name="components.dir" location="${project.dir}/_components"/>

--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -33,7 +33,7 @@
     <property name="ivy.local.jar.file" value="${lib.dir}/ivy.jar" />
         
     <!-- Set the verbosity level of the output. A higher value means more verbose output -->
-    <property name="outputLevel" value="1" />
+    <property name="outputLevel" value="2" />
     <script language="javascript"> <!-- Gives a script warning. It is advised to switch to Groovy, haven't figured that one out. -->
         var verboseMode = project.getProperty( "outputLevel" )
         project.getBuildListeners().firstElement().setMessageOutputLevel(verboseMode);
@@ -104,7 +104,7 @@
     
     <macrodef name="saxon-transform" description="Custom task to run an XSLT transformation using Saxon (HE)">
         <attribute name="style" description="The path to the stylesheet to use for the transformation"/>
-        <attribute name="in" description="The path to the input file"/>
+        <attribute name="in" description="The path to the input file" default="@{style}"/>
         <attribute name="out" description="The path to the output file"/>
         <element name="parameters" optional="yes" description="Optionally, a group of 'param' elements as understood by the XSLT task"/>
 
@@ -262,7 +262,33 @@
             </for>
         </sequential>
     </macrodef>
-
+    
+    <macrodef name="generate-loadresources" description="Generate a LoadResources TestScript to load all fixtures to the WildFHIR server.">
+        <sequential>
+            <!-- Calculate the relative path to the reference dir from the LoadResources output file-->
+            <!--<local name="loadresources.file"/>-->
+            <!--<local name="loadresources.file.dir"/>
+            <local name="reference.dir.relative"/>
+            <local name="reference.dir.relative.normalized"/>-->
+            <property name="loadresources.file" value="${build.dir}/${project}/_LoadResources/${project}-load-resources-purgecreateupdate-xml.xml"/>
+            <dirname property="loadresources.file.dir" file="${loadresources.file}"/>
+            <property name="reference.dir.loadresourcesrelative" location="${build.dir}/${project}/_reference" relative="true" basedir="${loadresources.file.dir}"/>
+            <!-- Convert backslashes to forward slashes if needed -->
+            <propertyregex property="reference.dir.loadresourcesrelative.normalized" input="${reference.dir.loadresourcesrelative}" regexp="[\\]" replace="/" global="true" defaultValue="${reference.dir.loadresourcesrelative}"/>
+            
+            <!--<!-\- Dummy input since @in is required. Should be more elegant -\->
+            <tempfile property="dummy.file" suffix=".xml" createfile="true" deleteonexit="true"/>-->
+            
+            <saxon-transform style="${xslt.dir}/generateLoadResources.xsl" out="${build.dir}/${project}/_LoadResources/${project}-load-resources-purgecreateupdate-xml.xml">
+                <parameters>
+                    <param name="referenceBase" expression="${reference.dir.loadresourcesrelative.normalized}"/>
+                    <param name="referenceDir" expression="${project.dir}/_reference/"/>
+                    <param name="project" expression="${project}"/>
+                </parameters>
+            </saxon-transform>
+        </sequential>
+    </macrodef>
+    
     <target name="cleanBuildDir">
         <sequential>
             <echo message="Deleting previous build dir"/>
@@ -331,6 +357,7 @@
                     <!-- Copy over all fixtures and rules -->
                     <echo message="Copying fixtures"/>
                     <copy-references references.file="${references.file}"/>
+                    <generate-loadresources/>
                 </sequential>
             </then>
             <else>

--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -34,7 +34,7 @@
     <property name="ivy.local.jar.file" value="${lib.dir}/ivy.jar" />
         
     <!-- Set the verbosity level of the output. A higher value means more verbose output -->
-    <property name="outputLevel" value="2" />
+    <property name="outputLevel" value="1" />
     <script language="javascript"> <!-- Gives a script warning. It is advised to switch to Groovy, haven't figured that one out. -->
         var verboseMode = project.getProperty( "outputLevel" )
         project.getBuildListeners().firstElement().setMessageOutputLevel(verboseMode);
@@ -266,20 +266,12 @@
     
     <macrodef name="generate-loadresources" description="Generate a LoadResources TestScript to load all fixtures to the WildFHIR server.">
         <sequential>
-            <!-- Calculate the relative path to the reference dir from the LoadResources output file-->
-            <!--<local name="loadresources.file"/>-->
-            <!--<local name="loadresources.file.dir"/>
-            <local name="reference.dir.relative"/>
-            <local name="reference.dir.relative.normalized"/>-->
             <property name="loadresources.file" value="${build.dir}/${project}/_LoadResources/${project}-load-resources-purgecreateupdate-xml.xml"/>
             <dirname property="loadresources.file.dir" file="${loadresources.file}"/>
             <property name="reference.dir.loadresourcesrelative" location="${build.dir}/${project}/_reference" relative="true" basedir="${loadresources.file.dir}"/>
             <!-- Convert backslashes to forward slashes if needed -->
             <propertyregex property="reference.dir.loadresourcesrelative.normalized" input="${reference.dir.loadresourcesrelative}" regexp="[\\]" replace="/" global="true" defaultValue="${reference.dir.loadresourcesrelative}"/>
-            
-            <!--<!-\- Dummy input since @in is required. Should be more elegant -\->
-            <tempfile property="dummy.file" suffix=".xml" createfile="true" deleteonexit="true"/>-->
-            
+                        
             <saxon-transform style="${xslt.dir}/generateLoadResources.xsl" out="${build.dir}/${project}/_LoadResources/${project}-load-resources-purgecreateupdate-xml.xml">
                 <parameters>
                     <param name="referenceBase" expression="${reference.dir.loadresourcesrelative.normalized}"/>

--- a/generate/schematron/NictizTestScript.sch
+++ b/generate/schematron/NictizTestScript.sch
@@ -28,6 +28,9 @@
             <sch:assert test="f:description[@value]">element 'description' with a value is required</sch:assert>
             <sch:assert test="count(*[local-name() != 'name' and local-name() != 'description']) > 0">tests may not be empty</sch:assert>
         </sch:rule>
+        <sch:rule context="f:assert">
+            <sch:assert test="not(@nts:stopTestOnFail) or @nts:stopTestOnFail = 'true' or @nts:stopTestOnFail = 'false'">Set stopTestOnFail to either 'true' or 'false' using the nts:stopTestOnFail attribute</sch:assert>
+        </sch:rule>
     </sch:pattern>
     
     <sch:pattern>

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -54,7 +54,7 @@
             </contact>
             <description value="Load Nictiz {$project} test resources using the update (PUT) operation of the target FHIR server for use in {$project} qualification testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
             <copyright value="© Nictiz 2020"/>
-            <xsl:for-each select="$xml1[for $i in $loadResourcesExcludeParsed return (if (not(contains(document-uri(ancestor::node()),$i))) then true() else false())]">
+            <xsl:for-each select="$xml1[for $i in $loadResourcesExcludeParsed return (if (not(contains(document-uri(ancestor::node()),normalize-space($i)))) then true() else false())]">
                 <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
                 <xsl:variable name="resId" select="concat(local-name(), '-', replace(replace(f:id/@value, 'Bearer ', ''), '\s', ''))"/>
                 <xsl:variable name="dn" select="document-uri(ancestor::node())"/>
@@ -64,7 +64,7 @@
                     </resource>
                 </fixture>
             </xsl:for-each>
-            <xsl:for-each select="$xml1[for $i in $loadResourcesExcludeParsed return (if (not(contains(document-uri(ancestor::node()),$i))) then true() else false())]">
+            <xsl:for-each select="$xml1[for $i in $loadResourcesExcludeParsed return (if (not(contains(document-uri(ancestor::node()),normalize-space($i)))) then true() else false())]">
                 <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
                 <xsl:variable name="resId" select="concat(local-name(), '-', replace(replace(f:id/@value, 'Bearer ', ''), '\s', ''))"/>
                 <variable>
@@ -113,7 +113,7 @@
             <test id="Step1-LoadTestResourceCreate">
                 <name value="Step1-LoadTestResourceCreate"/>
                 <description value="Load {$project} test resources using the update (PUT) operation of the target FHIR server for use in {$project} qualification testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
-                <xsl:for-each select="$xml1[for $i in $loadResourcesExcludeParsed return (if (not(contains(document-uri(ancestor::node()),$i))) then true() else false())][not(contains(f:id/@value, 'Bearer'))]">
+                <xsl:for-each select="$xml1[for $i in $loadResourcesExcludeParsed return (if (not(contains(document-uri(ancestor::node()),normalize-space($i)))) then true() else false())][not(contains(f:id/@value, 'Bearer'))]">
                     <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
                     <xsl:variable name="resId" select="concat(local-name(), '-', replace(replace(f:id/@value, 'Bearer ', ''), '\s', ''))"/>
                     <xsl:variable name="dn" select="document-uri(ancestor::node())"/>

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -17,12 +17,17 @@
     
     <xsl:param name="referenceDirNormalized">
         <xsl:choose>
-            <xsl:when test="not(starts-with($referenceDir, 'file:')) and (starts-with($referenceDir,'/') or matches($referenceDir,'^[A-Za-z]:[/\\]'))">
+            <xsl:when test="starts-with($referenceDir, 'file:')">
+                <xsl:value-of select="$referenceDir"/>
+            </xsl:when>
+            <xsl:when test="starts-with($referenceDir,'/')">
+                <!-- Unix style -->
+                <xsl:value-of select="concat('file:', translate($referenceDir,'\','/'))"/>
+            </xsl:when>
+            <xsl:when test="matches($referenceDir,'^[A-Za-z]:[/\\]')">
+                <!-- Windows style -->
                 <xsl:value-of select="concat('file:/',translate($referenceDir,'\','/'))"/>
             </xsl:when>
-            <xsl:otherwise>
-                <xsl:value-of select="$referenceDir"/>
-            </xsl:otherwise>
         </xsl:choose>
     </xsl:param>
     

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" xmlns:f="http://hl7.org/fhir" exclude-result-prefixes="#all" version="2.0">
+    <xd:doc scope="stylesheet">
+        <xd:desc>
+            <xd:p><xd:b>Updated on:</xd:b> Oct 21, 2020</xd:p>
+            <xd:p><xd:b>Author:</xd:b> Nictiz (AHE, AWE, JDU)</xd:p>
+            <xd:p/>
+        </xd:desc>
+    </xd:doc>
+
+    <xsl:output indent="yes" omit-xml-declaration="yes"/>
+
+    <!-- The path to the base folder of fixtures, relative to the output. Defaults to '../_reference'. -->
+    <xsl:param name="referenceBase" select="'../_reference/'"/>
+    <!-- The absolute path to the folder of fixtures -->
+    <xsl:param name="referenceDir"/>
+    
+    <xsl:param name="referenceDirNormalized">
+        <xsl:choose>
+            <xsl:when test="not(starts-with($referenceDir, 'file:')) and (starts-with($referenceDir,'/') or matches($referenceDir,'^[A-Za-z]:[/\\]'))">
+                <xsl:value-of select="concat('file:/',translate($referenceDir,'\','/'))"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$referenceDir"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:param>
+    
+    <xsl:param name="project"/>
+
+    <xd:doc>
+        <xd:desc/>
+    </xd:doc>
+    <xsl:template match="/">
+        <xsl:variable name="xml1" select="collection(iri-to-uri(concat(resolve-uri($referenceDirNormalized), '?select=', '*.xml;recurse=yes')))/f:*"/>
+        <xsl:processing-instruction name="xml-model">href="http://hl7.org/fhir/STU3/testscript.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"</xsl:processing-instruction>
+        <TestScript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd" xmlns="http://hl7.org/fhir">
+            <id value="AllergyIntolerance-fhir3-0-1-load-resources-createupdate-xml"/>
+            <url value="http://nictiz.nl/fhir/fhir3-0-1/TestScript/{$project}-load-resources-createupdate-xml"/>
+            <name value="Nictiz {$project} Load Test Resources - Create Update - XML"/>
+            <status value="active"/>
+            <date value="{current-dateTime()}"/>
+            <publisher value="Nictiz"/>
+            <contact>
+                <name value="MedMij"/>
+                <telecom>
+                    <system value="email"/>
+                    <value value="kwalificatie@medmij.nl"/>
+                    <use value="work"/>
+                </telecom>
+            </contact>
+            <description value="Load {$project} test resources using the update (PUT) operation of the target FHIR server for use in {$project} qualification testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
+            <copyright value="© Nictiz 2020"/>
+            <xsl:for-each select="$xml1">
+                <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
+                <xsl:variable name="resId" select="concat(local-name(), '-', replace(replace(f:id/@value, 'Bearer ', ''), '\s', ''))"/>
+                <xsl:variable name="dn" select="document-uri(ancestor::node())"/>
+                <fixture id="{$resId}-fx">
+                    <resource>
+                        <reference value="{$referenceBase}/{replace($dn, $referenceDirNormalized, '')}"/>
+                    </resource>
+                </fixture>
+            </xsl:for-each>
+            <xsl:for-each select="$xml1">
+                <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
+                <xsl:variable name="resId" select="concat(local-name(), '-', replace(replace(f:id/@value, 'Bearer ', ''), '\s', ''))"/>
+                <variable>
+                    <name value="{$resId}-id"/>
+                    <expression value="{local-name(.)}.id"/>
+                    <sourceId value="{$resId}-fx"/>
+                </variable>
+            </xsl:for-each>
+            <!-- variable T -->
+            <variable>
+                <name value="T"/>
+                <defaultValue value="${{CURRENTDATE}}"/>
+                <description value="Date that data and queries are expected to be relative to."/>
+            </variable>
+            <!--  Setup -->
+            <xsl:variable name="xml-token" select="collection(iri-to-uri(concat(resolve-uri($referenceDirNormalized), '?select=', '*token.xml;recurse=yes')))/f:*"/>
+            <setup>
+                <xsl:for-each select="$xml-token">
+                    <action>
+                        <operation>
+                            <type>
+                                <system value="http://touchstone.com/fhir/extended-operation-codes"/>
+                                <code value="purge"/>
+                            </type>
+                            <resource value="Patient"/>
+                            <accept value="xml"/>
+                            <contentType value="xml"/>
+                            <params value="/$purge"/>
+                            <requestHeader>
+                                <field value="Authorization"/>
+                                <value value="{f:id/@value}"/>
+                            </requestHeader>
+                        </operation>
+                    </action>
+                    <action>
+                        <assert>
+                            <description value="Confirm that the returned HTTP status is 200(OK)."/>
+                            <operator value="equals"/>
+                            <responseCode value="200"/>
+                        </assert>
+                    </action>
+                </xsl:for-each>
+            </setup>
+            <!-- Test -->
+            <test id="Step1-LoadTestResourceCreate">
+                <name value="Step1-LoadTestResourceCreate"/>
+                <description value="Load {$project} test resources using the update (PUT) operation of the target FHIR server for use in {$project} qualification testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
+                <xsl:for-each select="$xml1[not(contains(f:id/@value, 'Bearer'))]">
+                    <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
+                    <xsl:variable name="resId" select="concat(local-name(), '-', replace(replace(f:id/@value, 'Bearer ', ''), '\s', ''))"/>
+                    <xsl:variable name="dn" select="document-uri(ancestor::node())"/>
+                    <!--                    <xsl:comment> Create <xsl:value-of select="$resId"/></xsl:comment>-->
+                    <action>
+                        <operation>
+                            <type>
+                                <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                                <code value="updateCreate"/>
+                            </type>
+                            <resource value="{local-name(.)}"/>
+                            <accept value="xml"/>
+                            <contentType value="xml"/>
+                            <params value="/${{{$resId}-id}}"/>
+                            <requestHeader>
+                                <field value="Authorization"/>
+                                <!-- This Bearer token is a dedicated token for LoadResources purposes -->
+                                <value value="Bearer e317fc02-e8ff-40fe-9b22-f3c43fbf5613"/>
+                            </requestHeader>
+                            <sourceId value="{$resId}-fx"/>
+                        </operation>
+                    </action>
+                    <action>
+                        <assert>
+                            <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
+                            <operator value="in"/>
+                            <responseCode value="200,201"/>
+                        </assert>
+                    </action>
+                </xsl:for-each>
+            </test>
+        </TestScript>
+    </xsl:template>
+</xsl:stylesheet>

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -57,7 +57,6 @@
         </xsl:variable>
         
         <!-- Write out the TestScript resource -->
-        <xsl:processing-instruction name="xml-model">href="http://hl7.org/fhir/STU3/testscript.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"</xsl:processing-instruction>
         <TestScript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhir" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/testscript.xsd">
             <id value="{$project}-resources-purgecreateupdate-xml"/>
             <url value="http://nictiz.nl/fhir/TestScript/{$project}-load-resources-purgecreateupdate-xml"/>
@@ -163,8 +162,8 @@
                                 <field value="Authorization"/>
                                 <!-- This Bearer token is a dedicated token for LoadResources purposes -->
                                 <!--<value value="Bearer e317fc02-e8ff-40fe-9b22-f3c43fbf5613"/>-->
-                                <!-- Use patient token until dedicated Bearer token is active -->
-                                <value value="{f:id/@value}"/>
+                                <!-- Use first patient token until dedicated Bearer token is active -->
+                                <value value="{$tokens[1]/f:id/@value}"/>
                             </requestHeader>
                             <sourceId value="{$fixtureId}"/>
                         </operation>
@@ -187,7 +186,7 @@
         <xsl:variable name="normalizedId" select="replace($bearerLessId, '\s', '')"/>
         <xsl:variable name="fixtureId" select="concat(local-name(), '-', $normalizedId)"/>
         
-        <xsl:if test="not(matches($fixtureId, '[A-Za-z0-9\-\.]{1,64}'))">
+        <xsl:if test="not(matches($fixtureId, '^[A-Za-z0-9\-\.]{1,64}$'))">
             <xsl:message terminate="yes" select="concat('Not a valid id: ', $fixtureId)"/>
         </xsl:if>
         <xsl:value-of select="$fixtureId"/>

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -35,14 +35,24 @@
         <xd:desc/>
     </xd:doc>
     <xsl:template match="/">
-        <xsl:variable name="xml1" select="collection(iri-to-uri(concat(resolve-uri($referenceDirNormalized), '?select=', '*.xml;recurse=yes')))/f:*"/>
+        <xsl:variable name="xml1" as="item()*">
+            <xsl:variable name="collection" select="collection(iri-to-uri(concat(resolve-uri($referenceDirNormalized), '?select=', '*.xml;recurse=yes')))/f:*"/>
+            <xsl:choose>
+                <xsl:when test="normalize-space($loadResourcesExclude)">
+                    <xsl:sequence select="$collection[for $i in $loadResourcesExcludeParsed return (if (not(contains(document-uri(ancestor::node()),normalize-space($i)))) then true() else false())]"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:sequence select="$collection"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
         <xsl:processing-instruction name="xml-model">href="http://hl7.org/fhir/STU3/testscript.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"</xsl:processing-instruction>
         <TestScript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhir" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/testscript.xsd">
             <id value="{$project}-resources-purgecreateupdate-xml"/>
             <url value="http://nictiz.nl/fhir/TestScript/{$project}-load-resources-purgecreateupdate-xml"/>
             <name value="Nictiz {$project} Load Test Resources - Purge Create Update - XML"/>
             <status value="active"/>
-            <date value="{format-date(current-date(), '[D01]-[M01]-[Y0001]')}"/>
+            <date value="{format-date(current-date(), '[Y0001]-[M01]-[D01]')}"/>
             <publisher value="Nictiz"/>
             <contact>
                 <name value="MedMij"/>
@@ -54,7 +64,7 @@
             </contact>
             <description value="Load Nictiz {$project} test resources using the update (PUT) operation of the target FHIR server for use in {$project} qualification testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
             <copyright value="© Nictiz 2020"/>
-            <xsl:for-each select="$xml1[for $i in $loadResourcesExcludeParsed return (if (not(contains(document-uri(ancestor::node()),normalize-space($i)))) then true() else false())]">
+            <xsl:for-each select="$xml1">
                 <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
                 <xsl:variable name="resId" select="concat(local-name(), '-', replace(replace(f:id/@value, 'Bearer ', ''), '\s', ''))"/>
                 <xsl:variable name="dn" select="document-uri(ancestor::node())"/>
@@ -64,7 +74,7 @@
                     </resource>
                 </fixture>
             </xsl:for-each>
-            <xsl:for-each select="$xml1[for $i in $loadResourcesExcludeParsed return (if (not(contains(document-uri(ancestor::node()),normalize-space($i)))) then true() else false())]">
+            <xsl:for-each select="$xml1">
                 <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
                 <xsl:variable name="resId" select="concat(local-name(), '-', replace(replace(f:id/@value, 'Bearer ', ''), '\s', ''))"/>
                 <variable>
@@ -113,7 +123,7 @@
             <test id="Step1-LoadTestResourceCreate">
                 <name value="Step1-LoadTestResourceCreate"/>
                 <description value="Load {$project} test resources using the update (PUT) operation of the target FHIR server for use in {$project} qualification testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
-                <xsl:for-each select="$xml1[for $i in $loadResourcesExcludeParsed return (if (not(contains(document-uri(ancestor::node()),normalize-space($i)))) then true() else false())][not(contains(f:id/@value, 'Bearer'))]">
+                <xsl:for-each select="$xml1[not(contains(f:id/@value, 'Bearer'))]">
                     <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
                     <xsl:variable name="resId" select="concat(local-name(), '-', replace(replace(f:id/@value, 'Bearer ', ''), '\s', ''))"/>
                     <xsl:variable name="dn" select="document-uri(ancestor::node())"/>

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -1,56 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" xmlns:f="http://hl7.org/fhir" exclude-result-prefixes="#all" version="2.0">
-    <xd:doc scope="stylesheet">
-        <xd:desc>
-            <xd:p><xd:b>Updated on:</xd:b> Oct 21, 2020</xd:p>
-            <xd:p><xd:b>Author:</xd:b> Nictiz (AHE, AWE, JDU)</xd:p>
-            <xd:p/>
-        </xd:desc>
-    </xd:doc>
+    <!-- Stylesheet to write out the special TestScript resource that is used to load all fixtures to the test 
+         server (the load script) -->
 
     <xsl:output indent="yes" omit-xml-declaration="yes"/>
 
     <!-- The path to the base folder of fixtures, relative to the output. Defaults to '../_reference'. -->
     <xsl:param name="referenceBase" select="'../_reference/'"/>
+    
     <!-- The absolute path to the folder of fixtures -->
     <xsl:param name="referenceDir"/>
-    
-    <xsl:param name="referenceDirNormalized">
-        <xsl:choose>
-            <xsl:when test="starts-with($referenceDir, 'file:')">
-                <xsl:value-of select="$referenceDir"/>
-            </xsl:when>
-            <xsl:when test="starts-with($referenceDir,'/')">
-                <!-- Unix style -->
-                <xsl:value-of select="concat('file:', translate($referenceDir,'\','/'))"/>
-            </xsl:when>
-            <xsl:when test="matches($referenceDir,'^[A-Za-z]:[/\\]')">
-                <!-- Windows style -->
-                <xsl:value-of select="concat('file:/',translate($referenceDir,'\','/'))"/>
-            </xsl:when>
-        </xsl:choose>
-    </xsl:param>
-    
+        
+    <!-- The identifier for this project -->
     <xsl:param name="project"/>
+    
+    <!-- Comma-separated list of paths to exclude -->
     <xsl:param name="loadResourcesExclude"/>
-    <!-- Assumes loadResourcesExclude can be comma-separated -->
-    <xsl:param name="loadResourcesExcludeParsed" select="tokenize(translate($loadResourcesExclude,'\','/'),',')"/>
 
-    <xd:doc>
-        <xd:desc/>
-    </xd:doc>
     <xsl:template match="/">
-        <xsl:variable name="xml1" as="item()*">
-            <xsl:variable name="collection" select="collection(iri-to-uri(concat(resolve-uri($referenceDirNormalized), '?select=', '*.xml;recurse=yes')))/f:*"/>
+        
+        <!-- Convert the reference to a file:// URL and make sure it ends with a slash. -->
+        <xsl:variable name="referenceDirAsUrl">
+            <xsl:variable name="fileUrl">
+                <xsl:choose>
+                    <xsl:when test="starts-with($referenceDir, 'file:')">
+                        <xsl:value-of select="$referenceDir"/>
+                    </xsl:when>
+                    <xsl:when test="starts-with($referenceDir,'/')">
+                        <!-- Unix style -->
+                        <xsl:value-of select="concat('file:', translate($referenceDir,'\','/'))"/>
+                    </xsl:when>
+                    <xsl:when test="matches($referenceDir,'^[A-Za-z]:[/\\]')">
+                        <!-- Windows style -->
+                        <xsl:value-of select="concat('file:/',translate($referenceDir,'\','/'))"/>
+                    </xsl:when>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:value-of select="if (ends-with($fileUrl, '/')) then $fileUrl else concat($fileUrl, '/')"/>
+        </xsl:variable>
+        
+        <!-- Make sure the referenceBase ends with a slash. -->
+        <xsl:variable name="referenceBaseSanitized" select="if (ends-with($referenceBase, '/')) then $referenceBase else concat($referenceBase, '/')"/>
+        
+        <!-- Collect all fixtures as file URLs -->
+        <xsl:variable name="fixtures" as="item()*">
+            <xsl:variable name="excludedPaths" select="tokenize(translate($loadResourcesExclude,'\','/'),',')"/>
+            <xsl:variable name="fixturesUnfiltered" select="collection(iri-to-uri(concat(resolve-uri($referenceDirAsUrl), '?select=', '*.xml;recurse=yes')))/f:*"/>
             <xsl:choose>
                 <xsl:when test="normalize-space($loadResourcesExclude)">
-                    <xsl:sequence select="$collection[for $i in $loadResourcesExcludeParsed return (if (not(contains(document-uri(ancestor::node()),normalize-space($i)))) then true() else false())]"/>
+                    <xsl:sequence select="$fixturesUnfiltered[for $excludedPath in $excludedPaths return (not(contains(document-uri(ancestor::node()),normalize-space($excludedPath))))]"/>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:sequence select="$collection"/>
+                    <xsl:sequence select="$fixturesUnfiltered"/>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
+        
+        <!-- Write out the TestScript resource -->
         <xsl:processing-instruction name="xml-model">href="http://hl7.org/fhir/STU3/testscript.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"</xsl:processing-instruction>
         <TestScript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhir" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/testscript.xsd">
             <id value="{$project}-resources-purgecreateupdate-xml"/>
@@ -69,35 +75,44 @@
             </contact>
             <description value="Load Nictiz {$project} test resources using the update (PUT) operation of the target FHIR server for use in {$project} qualification testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
             <copyright value="© Nictiz 2020"/>
-            <xsl:for-each select="$xml1">
+            
+            <!-- Write out all fixture references -->
+            <xsl:for-each select="$fixtures">
                 <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
-                <xsl:variable name="resId" select="concat(local-name(), '-', replace(replace(f:id/@value, 'Bearer ', ''), '\s', ''))"/>
-                <xsl:variable name="dn" select="document-uri(ancestor::node())"/>
-                <fixture id="{$resId}-fx">
+                <xsl:variable name="fixtureId">
+                    <xsl:call-template name="generateFixtureId"/>
+                </xsl:variable>
+                <fixture id="{$fixtureId}">
                     <resource>
-                        <reference value="{$referenceBase}/{replace($dn, $referenceDirNormalized, '')}"/>
+                        <reference value="{replace(document-uri(ancestor::node()), $referenceDirAsUrl, $referenceBaseSanitized)}"/>
                     </resource>
                 </fixture>
             </xsl:for-each>
-            <xsl:for-each select="$xml1">
+            
+            <!-- Write out variables that read the id's from all fixtures -->
+            <xsl:for-each select="$fixtures">
                 <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
-                <xsl:variable name="resId" select="concat(local-name(), '-', replace(replace(f:id/@value, 'Bearer ', ''), '\s', ''))"/>
+                <xsl:variable name="fixtureId">
+                    <xsl:call-template name="generateFixtureId"/>
+                </xsl:variable>
                 <variable>
-                    <name value="{$resId}-id"/>
+                    <name value="{$fixtureId}-id"/>
                     <expression value="{local-name(.)}.id"/>
-                    <sourceId value="{$resId}-fx"/>
+                    <sourceId value="{$fixtureId}"/>
                 </variable>
             </xsl:for-each>
+            
             <!-- variable T -->
             <variable>
                 <name value="T"/>
                 <defaultValue value="${{CURRENTDATE}}"/>
                 <description value="Date that data and queries are expected to be relative to."/>
             </variable>
-            <!--  Setup -->
-            <xsl:variable name="xml-token" select="collection(iri-to-uri(concat(resolve-uri($referenceDirNormalized), '?select=', '*token.xml;recurse=yes')))/f:*"/>
+            
+            <!-- Purge Patients in setup -->
+            <xsl:variable name="tokens" select="collection(iri-to-uri(concat(resolve-uri($referenceDirAsUrl), '?select=', '*token.xml;recurse=yes')))/f:*"/>
             <setup>
-                <xsl:for-each select="$xml-token">
+                <xsl:for-each select="$tokens">
                     <action>
                         <operation>
                             <type>
@@ -124,14 +139,16 @@
                     </action>
                 </xsl:for-each>
             </setup>
-            <!-- Test -->
+            
+            <!-- PUT all fixtures in test -->
             <test id="Step1-LoadTestResourceCreate">
                 <name value="Step1-LoadTestResourceCreate"/>
                 <description value="Load {$project} test resources using the update (PUT) operation of the target FHIR server for use in {$project} qualification testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
-                <xsl:for-each select="$xml1[not(contains(f:id/@value, 'Bearer'))]">
+                <xsl:for-each select="$fixtures[not(contains(f:id/@value, 'Bearer'))]">
                     <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
-                    <xsl:variable name="resId" select="concat(local-name(), '-', replace(replace(f:id/@value, 'Bearer ', ''), '\s', ''))"/>
-                    <xsl:variable name="dn" select="document-uri(ancestor::node())"/>
+                    <xsl:variable name="fixtureId">
+                        <xsl:call-template name="generateFixtureId"/>
+                    </xsl:variable>
                     <action>
                         <operation>
                             <type>
@@ -141,7 +158,7 @@
                             <resource value="{local-name(.)}"/>
                             <accept value="xml"/>
                             <contentType value="xml"/>
-                            <params value="/${{{$resId}-id}}"/>
+                            <params value="/${{{$fixtureId}-id}}"/>
                             <requestHeader>
                                 <field value="Authorization"/>
                                 <!-- This Bearer token is a dedicated token for LoadResources purposes -->
@@ -149,7 +166,7 @@
                                 <!-- Use patient token until dedicated Bearer token is active -->
                                 <value value="{f:id/@value}"/>
                             </requestHeader>
-                            <sourceId value="{$resId}-fx"/>
+                            <sourceId value="{$fixtureId}"/>
                         </operation>
                     </action>
                     <action>
@@ -162,5 +179,17 @@
                 </xsl:for-each>
             </test>
         </TestScript>
+    </xsl:template>
+    
+    <!-- Generate a fixture id for the provided resource, based on the type and the resource.id -->
+    <xsl:template name="generateFixtureId" as="xs:string">
+        <xsl:variable name="bearerLessId" select="replace(f:id/@value, 'Bearer ', '')"/>
+        <xsl:variable name="normalizedId" select="replace($bearerLessId, '\s', '')"/>
+        <xsl:variable name="fixtureId" select="concat(local-name(), '-', $normalizedId)"/>
+        
+        <xsl:if test="not(matches($fixtureId, '[A-Za-z0-9\-\.]{1,64}'))">
+            <xsl:message terminate="yes" select="concat('Not a valid id: ', $fixtureId)"/>
+        </xsl:if>
+        <xsl:value-of select="$fixtureId"/>
     </xsl:template>
 </xsl:stylesheet>

--- a/generate/xslt/generateTestScript.xsl
+++ b/generate/xslt/generateTestScript.xsl
@@ -231,7 +231,7 @@
         <xsl:copy>
             <xsl:apply-templates select="@*" mode="#current"/>
             <xsl:choose>
-                <xsl:when test="nts:stopTestOnFail[@value='true']">
+                <xsl:when test="@nts:stopTestOnFail='true'">
                     <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                         <valueBoolean value="true"/>
                     </extension>

--- a/generate/xslt/generateTestScript.xsl
+++ b/generate/xslt/generateTestScript.xsl
@@ -432,6 +432,7 @@
         </xsl:copy>
     </xsl:template>
     
+    <!-- Fix to pretty print output - strip-space does not seem to function when being called from ANT -->
     <xsl:template match="text()[not(normalize-space(.))]" mode="#all"/>
     
     <!-- === Here be functions ==================================================================================== -->

--- a/generate/xslt/generateTestScript.xsl
+++ b/generate/xslt/generateTestScript.xsl
@@ -432,6 +432,8 @@
         </xsl:copy>
     </xsl:template>
     
+    <xsl:template match="text()[not(normalize-space(.))]" mode="#all"/>
+    
     <!-- === Here be functions ==================================================================================== -->
     
     <!-- Construct an XML file path from the elements.

--- a/generate/xslt/generateTestScript.xsl
+++ b/generate/xslt/generateTestScript.xsl
@@ -69,6 +69,9 @@
         <xsl:copy>
             <xsl:apply-templates select="node()|@*" mode="#current"/>
         </xsl:copy>
+        <meta>
+            <profile value="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript"/>
+        </meta>
         <url value="{$url}"/>
     </xsl:template>
 
@@ -220,6 +223,26 @@
                 <accept value="{lower-case($expectedResponseFormat)}"/>
             </xsl:if>
             <xsl:apply-templates select="f:*[not(local-name()=$pre-accept)]" mode="#current"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <!--Add TouchStone assert-stopTestOnFail extension by default.-->
+    <xsl:template match="f:TestScript/f:test/f:action/f:assert" mode="filter">
+        <xsl:copy>
+            <xsl:apply-templates select="@*" mode="#current"/>
+            <xsl:choose>
+                <xsl:when test="nts:stopTestOnFail[@value='true']">
+                    <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+                        <valueBoolean value="true"/>
+                    </extension>
+                </xsl:when>
+                <xsl:otherwise>
+                    <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+                        <valueBoolean value="false"/>
+                    </extension>
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:apply-templates select="node()" mode="#current"/>
         </xsl:copy>
     </xsl:template>
     


### PR DESCRIPTION
Het 'createTestScript.xsl' wat in diverse _util mappen leefde geïntegreerd in build.

Getest op MP en Questionnaires. Het resultaat moet bij iedere standaard even goed vergeleken worden met wat er al bestond, op zoek naar mogelijke uitzonderingen. 

Voor MP is op het moment de LoadResource gesplitst vanwege performance redenen. Dit zou opgelost kunnen worden door het resultaat van de build te splitsen met een losse XSLT in een custom build.xml.

Het proces gaat uit van een Patient token waarvan de bestandsnaam op 'token.xml' eindigt en waarvan het id met 'Bearer' begint. Dat was impliciet zo, maar is nu even expliciet gemaakt in de README. Alexander heeft dit bij GPData bijvoorbeeld anders gedaan (en vervolgens de bestandsnaam van de token hard gecodeerd), dus dat moet even omgezet worden.

Voor Questionnaires moet er in de projectmap een bestand `build.properties` worden aangemaakt met inhoud:
`loadresources.exclude = _reference/resources/resources-specific`

Het proces is getest met zowel géén `build.properties` als een `build.properties` met alleen `loadresources.exclude =` als inhoud. We zouden dus in iedere src projectmap een build.properties met lege parameter kunnen toevoegen om de functie zichtbaarder te maken.

