### PR TITLE
loadRes-fixes: various fixes following GPData and Images

### DIFF
--- a/generate/README.md
+++ b/generate/README.md
@@ -226,9 +226,10 @@ Because of the verbosity of the ANT build, the logging level is set to 1 (warnin
 
 ### 1.2.1
 - Fixed a bug where a comma separated list in `loadresources.exclude` caused the process to crash.
-- Generated fixture-ids longer than 64 characters are stripped.
+- Fixed a bug were the process would crash if `loadresources.exclude` is not set.
+- Ids of fixtures that are added to LoadResources are validated.
 - Added support for asterisk wildcards in `loadresources.exclude`.
-- Do not genereate LoadResources script if there are no fixtures to generate it from.
+- A LoadResources script is not generated if there are no fixtures to generate it from.
 
 ### 1.2.0
 - A LoadResources script is now generated for a project

--- a/generate/README.md
+++ b/generate/README.md
@@ -224,6 +224,11 @@ Because of the verbosity of the ANT build, the logging level is set to 1 (warnin
 
 ## Changelog
 
+### 1.2.1
+- Fixed a bug where a comma separated list in `loadresources.exclude` caused the process to crash.
+- Generated fixture-ids longer than 64 characters are stripped.
+- Added support for asterisk wildcards in `loadresources.exclude`.
+
 ### 1.2.0
 - A LoadResources script is now generated for a project
 - TouchStone stopTestOnFail extension is added to each assert

--- a/generate/README.md
+++ b/generate/README.md
@@ -228,6 +228,7 @@ Because of the verbosity of the ANT build, the logging level is set to 1 (warnin
 - Fixed a bug where a comma separated list in `loadresources.exclude` caused the process to crash.
 - Generated fixture-ids longer than 64 characters are stripped.
 - Added support for asterisk wildcards in `loadresources.exclude`.
+- Do not genereate LoadResources script if there are no fixtures to generate it from.
 
 ### 1.2.0
 - A LoadResources script is now generated for a project

--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -271,8 +271,8 @@
             <property name="reference.dir.loadresourcesrelative" location="${build.dir}/${project}/_reference" relative="true" basedir="${loadresources.file.dir}"/>
             <!-- Convert backslashes to forward slashes if needed -->
             <propertyregex property="reference.dir.loadresourcesrelative.normalized" input="${reference.dir.loadresourcesrelative}" regexp="[\\]" replace="/" global="true" defaultValue="${reference.dir.loadresourcesrelative}"/>
-                        
-            <saxon-transform style="${xslt.dir}/generateLoadResources.xsl" out="${build.dir}/${project}/_LoadResources/${project}-load-resources-purgecreateupdate-xml.xml">
+            
+            <saxon-transform style="${xslt.dir}/generateLoadResources.xsl" out="${loadresources.file}">
                 <parameters>
                     <param name="referenceBase" expression="${reference.dir.loadresourcesrelative.normalized}"/>
                     <param name="referenceDir" expression="${project.dir}/_reference/"/>
@@ -280,6 +280,14 @@
                     <param name="loadResourcesExclude" expression="${loadresources.exclude}"/>
                 </parameters>
             </saxon-transform>
+            
+            <!-- Check if output is empty. If yes, delete -->
+            <if>
+                <length file="${loadresources.file}" when="equal" length="0" />
+                <then>
+                    <delete dir="${loadresources.file.dir}"/>
+                </then>
+            </if>
         </sequential>
     </macrodef>
     

--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -311,6 +311,9 @@
         <property name="components.dir.absolute" location="${components.dir}"/>
         <property name="commoncomponents.dir.absolute" location="${commoncomponents.dir}"/>
         
+        <!-- Set default loadresources.exclude to nothing -->
+        <property name="loadresources.exclude" value=""/>
+        
         <!-- Collect the XML files to transform -->
         <fileset id="nts.files" dir="${src.dir}/${project}">
             <include name="*/**/*.xml"/>

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -44,11 +44,11 @@
         
         <!-- Collect all non-bearer fixtures as file URLs -->
         <xsl:variable name="fixtures" as="item()*">
-            <xsl:variable name="excludedPaths" select="tokenize(translate($loadResourcesExclude,'\','/'),',')"/>
+            <xsl:variable name="excludedPaths" select="tokenize(replace(replace(translate($loadResourcesExclude,'\','/'), '[.]','[.]'),'[*]','.+?'),',')"/>
             <xsl:variable name="fixturesUnfiltered" select="collection(iri-to-uri(concat(resolve-uri($referenceDirAsUrl), '?select=', '*.xml;recurse=yes')))/f:*[not(contains(f:id/@value, 'Bearer'))]"/>
             <xsl:choose>
                 <xsl:when test="normalize-space($loadResourcesExclude)">
-                    <xsl:sequence select="$fixturesUnfiltered[for $excludedPath in $excludedPaths return (not(contains(document-uri(ancestor::node()),normalize-space($excludedPath))))]"/>
+                    <xsl:sequence select="$fixturesUnfiltered[not(some $excludedPath in $excludedPaths satisfies (matches(document-uri(ancestor::node()),normalize-space($excludedPath))))]"/>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:sequence select="$fixturesUnfiltered"/>
@@ -185,7 +185,7 @@
     <!-- Generate a fixture id for the provided resource, based on the type and the resource.id -->
     <xsl:template name="generateFixtureId" as="xs:string">
         <xsl:variable name="normalizedId" select="replace(f:id/@value, '\s', '')"/>
-        <xsl:variable name="fixtureId" select="concat(local-name(), '-', $normalizedId)"/>
+        <xsl:variable name="fixtureId" select="substring(concat(local-name(), '-', $normalizedId),1,64)"/>
         
         <xsl:if test="not(matches($fixtureId, '^[A-Za-z0-9\-\.]{1,64}$'))">
             <xsl:message terminate="yes" select="concat('Not a valid id: ', $fixtureId)"/>

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -195,17 +195,22 @@
         </xsl:choose>
     </xsl:template>
     
-    <!-- Generate a fixture id for the provided resource, based on the type and the resource.id -->
+    <!-- Construct a fixture id for the provided resource, based on the type and the resource.id.
+         If this constructed id is too long, a generated one that's harder to recognize will be used. -->
     <xsl:template name="generateFixtureId" as="xs:string">
-        <xsl:variable name="normalizedId" select="replace(f:id/@value, '\s', '')"/>
-        <xsl:variable name="fixtureId" select="concat(local-name(), '-', $normalizedId)"/>
         
+        <!-- Check if the resource id is a valid FHIR id -->
+        <xsl:if test="not(matches(f:id/@value, '^[A-Za-z0-9\-\.]{1,64}$'))">
+            <xsl:message terminate="yes" select="concat('Invalid FHIR id: ', f:id/@value)"/>
+        </xsl:if>
+
+        <xsl:variable name="fixtureId" select="concat(local-name(), '-', f:id/@value)"/>
         <xsl:choose>
             <xsl:when test="matches($fixtureId, '^[A-Za-z0-9\-\.]{1,64}$')">
                 <xsl:value-of select="$fixtureId"/>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:value-of select="substring(concat(local-name(), '-', generate-id(.), '-', $normalizedId),1,64)"/>
+                <xsl:value-of select="substring(concat(local-name(), '-', generate-id(.), '-', f:id/@value),1,64)"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -66,127 +66,127 @@
         
         <xsl:choose>
             <xsl:when test="$fixtures">
-                <!-- Write out the TestScript resource -->
-                <TestScript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhir" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/testscript.xsd">
-                    <id value="{$project}-resources-purgecreateupdate-xml"/>
-                    <url value="http://nictiz.nl/fhir/TestScript/{$project}-load-resources-purgecreateupdate-xml"/>
-                    <name value="Nictiz {$project} Load Test Resources - Purge Create Update - XML"/>
-                    <status value="active"/>
-                    <date value="{format-date(current-date(), '[Y0001]-[M01]-[D01]')}"/>
-                    <publisher value="Nictiz"/>
-                    <contact>
-                        <name value="MedMij"/>
-                        <telecom>
-                            <system value="email"/>
-                            <value value="kwalificatie@nictiz.nl"/>
-                            <use value="work"/>
-                        </telecom>
-                    </contact>
-                    <description value="Load Nictiz {$project} test resources using the update (PUT) operation of the target FHIR server for use in {$project} qualification testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
-                    <copyright value="© Nictiz 2020"/>
-                    
-                    <!-- Write out all fixture references -->
-                    <xsl:for-each select="$fixtures">
-                        <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
-                        <xsl:variable name="fixtureId">
-                            <xsl:call-template name="generateFixtureId"/>
-                        </xsl:variable>
-                        <fixture id="{$fixtureId}">
-                            <resource>
-                                <reference value="{replace(document-uri(ancestor::node()), $referenceDirAsUrl, $referenceBaseSanitized)}"/>
-                            </resource>
-                        </fixture>
-                    </xsl:for-each>
-                    
-                    <!-- Write out variables that read the id's from all fixtures -->
-                    <xsl:for-each select="$fixtures">
-                        <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
-                        <xsl:variable name="fixtureId">
-                            <xsl:call-template name="generateFixtureId"/>
-                        </xsl:variable>
-                        <variable>
-                            <name value="{$fixtureId}-id"/>
-                            <expression value="{local-name(.)}.id"/>
+        <!-- Write out the TestScript resource -->
+        <TestScript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhir" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/testscript.xsd">
+            <id value="{$project}-resources-purgecreateupdate-xml"/>
+            <url value="http://nictiz.nl/fhir/TestScript/{$project}-load-resources-purgecreateupdate-xml"/>
+            <name value="Nictiz {$project} Load Test Resources - Purge Create Update - XML"/>
+            <status value="active"/>
+            <date value="{format-date(current-date(), '[Y0001]-[M01]-[D01]')}"/>
+            <publisher value="Nictiz"/>
+            <contact>
+                <name value="MedMij"/>
+                <telecom>
+                    <system value="email"/>
+                    <value value="kwalificatie@nictiz.nl"/>
+                    <use value="work"/>
+                </telecom>
+            </contact>
+            <description value="Load Nictiz {$project} test resources using the update (PUT) operation of the target FHIR server for use in {$project} qualification testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
+            <copyright value="© Nictiz 2020"/>
+            
+            <!-- Write out all fixture references -->
+            <xsl:for-each select="$fixtures">
+                <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
+                <xsl:variable name="fixtureId">
+                    <xsl:call-template name="generateFixtureId"/>
+                </xsl:variable>
+                <fixture id="{$fixtureId}">
+                    <resource>
+                        <reference value="{replace(document-uri(ancestor::node()), $referenceDirAsUrl, $referenceBaseSanitized)}"/>
+                    </resource>
+                </fixture>
+            </xsl:for-each>
+            
+            <!-- Write out variables that read the id's from all fixtures -->
+            <xsl:for-each select="$fixtures">
+                <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
+                <xsl:variable name="fixtureId">
+                    <xsl:call-template name="generateFixtureId"/>
+                </xsl:variable>
+                <variable>
+                    <name value="{$fixtureId}-id"/>
+                    <expression value="{local-name(.)}.id"/>
+                    <sourceId value="{$fixtureId}"/>
+                </variable>
+            </xsl:for-each>
+            
+            <!-- variable T -->
+            <variable>
+                <name value="T"/>
+                <defaultValue value="${{CURRENTDATE}}"/>
+                <description value="Date that data and queries are expected to be relative to."/>
+            </variable>
+            
+            <!-- Purge Patients in setup -->
+            <setup>
+                <xsl:for-each select="$tokens">
+                    <action>
+                        <operation>
+                            <type>
+                                <system value="http://touchstone.com/fhir/extended-operation-codes"/>
+                                <code value="purge"/>
+                            </type>
+                            <resource value="Patient"/>
+                            <accept value="xml"/>
+                            <contentType value="xml"/>
+                            <params value="/$purge"/>
+                            <requestHeader>
+                                <field value="Authorization"/>
+                                <value value="{f:id/@value}"/>
+                            </requestHeader>
+                        </operation>
+                    </action>
+                    <action>
+                        <assert>
+                            <description
+                                value="Confirm that the returned HTTP status is 200(OK) or 204(No Content)"/>
+                            <operator value="in"/>
+                            <responseCode value="200,204"/>
+                        </assert>
+                    </action>
+                </xsl:for-each>
+            </setup>
+            
+            <!-- PUT all fixtures in test -->
+            <test id="Step1-LoadTestResourceCreate">
+                <name value="Step1-LoadTestResourceCreate"/>
+                <description value="Load {$project} test resources using the update (PUT) operation of the target FHIR server for use in {$project} qualification testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
+                <xsl:for-each select="$fixtures">
+                    <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
+                    <xsl:variable name="fixtureId">
+                        <xsl:call-template name="generateFixtureId"/>
+                    </xsl:variable>
+                    <action>
+                        <operation>
+                            <type>
+                                <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                                <code value="updateCreate"/>
+                            </type>
+                            <resource value="{local-name(.)}"/>
+                            <accept value="xml"/>
+                            <contentType value="xml"/>
+                            <params value="/${{{$fixtureId}-id}}"/>
+                            <requestHeader>
+                                <field value="Authorization"/>
+                                <!-- This Bearer token is a dedicated token for LoadResources purposes -->
+                                <!--<value value="Bearer e317fc02-e8ff-40fe-9b22-f3c43fbf5613"/>-->
+                                <!-- Use first patient token until dedicated Bearer token is active -->
+                                <value value="{$tokens[1]/f:id/@value}"/>
+                            </requestHeader>
                             <sourceId value="{$fixtureId}"/>
-                        </variable>
-                    </xsl:for-each>
-                    
-                    <!-- variable T -->
-                    <variable>
-                        <name value="T"/>
-                        <defaultValue value="${{CURRENTDATE}}"/>
-                        <description value="Date that data and queries are expected to be relative to."/>
-                    </variable>
-                    
-                    <!-- Purge Patients in setup -->
-                    <setup>
-                        <xsl:for-each select="$tokens">
-                            <action>
-                                <operation>
-                                    <type>
-                                        <system value="http://touchstone.com/fhir/extended-operation-codes"/>
-                                        <code value="purge"/>
-                                    </type>
-                                    <resource value="Patient"/>
-                                    <accept value="xml"/>
-                                    <contentType value="xml"/>
-                                    <params value="/$purge"/>
-                                    <requestHeader>
-                                        <field value="Authorization"/>
-                                        <value value="{f:id/@value}"/>
-                                    </requestHeader>
-                                </operation>
-                            </action>
-                            <action>
-                                <assert>
-                                    <description
-                                        value="Confirm that the returned HTTP status is 200(OK) or 204(No Content)"/>
-                                    <operator value="in"/>
-                                    <responseCode value="200,204"/>
-                                </assert>
-                            </action>
-                        </xsl:for-each>
-                    </setup>
-                    
-                    <!-- PUT all fixtures in test -->
-                    <test id="Step1-LoadTestResourceCreate">
-                        <name value="Step1-LoadTestResourceCreate"/>
-                        <description value="Load {$project} test resources using the update (PUT) operation of the target FHIR server for use in {$project} qualification testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
-                        <xsl:for-each select="$fixtures">
-                            <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
-                            <xsl:variable name="fixtureId">
-                                <xsl:call-template name="generateFixtureId"/>
-                            </xsl:variable>
-                            <action>
-                                <operation>
-                                    <type>
-                                        <system value="http://hl7.org/fhir/testscript-operation-codes"/>
-                                        <code value="updateCreate"/>
-                                    </type>
-                                    <resource value="{local-name(.)}"/>
-                                    <accept value="xml"/>
-                                    <contentType value="xml"/>
-                                    <params value="/${{{$fixtureId}-id}}"/>
-                                    <requestHeader>
-                                        <field value="Authorization"/>
-                                        <!-- This Bearer token is a dedicated token for LoadResources purposes -->
-                                        <!--<value value="Bearer e317fc02-e8ff-40fe-9b22-f3c43fbf5613"/>-->
-                                        <!-- Use first patient token until dedicated Bearer token is active -->
-                                        <value value="{$tokens[1]/f:id/@value}"/>
-                                    </requestHeader>
-                                    <sourceId value="{$fixtureId}"/>
-                                </operation>
-                            </action>
-                            <action>
-                                <assert>
-                                    <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
-                                    <operator value="in"/>
-                                    <responseCode value="200,201"/>
-                                </assert>
-                            </action>
-                        </xsl:for-each>
-                    </test>
-                </TestScript>
+                        </operation>
+                    </action>
+                    <action>
+                        <assert>
+                            <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
+                            <operator value="in"/>
+                            <responseCode value="200,201"/>
+                        </assert>
+                    </action>
+                </xsl:for-each>
+            </test>
+        </TestScript>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:message>No LoadResources to generate</xsl:message>
@@ -198,11 +198,15 @@
     <!-- Generate a fixture id for the provided resource, based on the type and the resource.id -->
     <xsl:template name="generateFixtureId" as="xs:string">
         <xsl:variable name="normalizedId" select="replace(f:id/@value, '\s', '')"/>
-        <xsl:variable name="fixtureId" select="substring(concat(local-name(), '-', $normalizedId),1,64)"/>
+        <xsl:variable name="fixtureId" select="concat(local-name(), '-', $normalizedId)"/>
         
-        <xsl:if test="not(matches($fixtureId, '^[A-Za-z0-9\-\.]{1,64}$'))">
-            <xsl:message terminate="yes" select="concat('Not a valid id: ', $fixtureId)"/>
-        </xsl:if>
-        <xsl:value-of select="$fixtureId"/>
+        <xsl:choose>
+            <xsl:when test="matches($fixtureId, '^[A-Za-z0-9\-\.]{1,64}$')">
+                <xsl:value-of select="$fixtureId"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="substring(concat(local-name(), '-', generate-id(.), '-', $normalizedId),1,64)"/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
GPData liet wat bugs zien:

De volgende loadresources.exclude was gewenst:
`loadresources.exclude = _reference/resources-query-send/medmij-gpdata-observation-contact*-S.xml,_reference/resources-query-send/medmij-gpdata-observation-contact*-O.xml`

Dus comma separated én met * wildcards, omdat je anders vanuit een automatisch gegenereerde map fixtures een handmatige sorteerstap moet volgen (of alle individuele fixtures in loadresources.exclude moest toevoegen). Comma separated werkte uberhaupt niet, omdat de originele situatie een sequence (true, false) binnen de blokhaken teruggaf in plaats van 1 boolean. Daarnaast naar regex gewisseld om de wildcard mogelijk te maken.

Daarnaast werd 1 gegenereerd id langer dan 64 karakters. Is substring() voldoende of is dat 'te dom' (moet er nog op uniqueness worden gecontroleerd)?
