### PR TITLE
Fix the broken components.dir parameter

### DIFF
--- a/generate/README.md
+++ b/generate/README.md
@@ -233,7 +233,7 @@ For the project build file, a particular folder structure is expected:
 - Project1/          : A project dir
   - build.properties : A file where parameters to the build script may be set (see below).
   - InputFolder1/    : One or more dirs containg NTS files. WARNING: all folder names starting with an underscore are ignored, while all other folders are included!
-  - \_components/    : The components specific for that project
+  - \_components/    : The components specific for that project - may be overridden using the components.dir parameter
   - \_reference/     : The fixtures and rules for that project. This folder is copied verbatim to the output folder. 
 ```
 
@@ -247,7 +247,6 @@ The following build script parameters are required:
 
 The following optional parameters may be used:
 - `outputLevel=<number>`: Increase or decrease verbosity of the build script (default = 1).
-- `reference.dir=/path/to/project/fixtures`: The (base) location for the fixtures for this project. Should be an absolute or relative location, compared to `build.xml`.
 - `components.dir=/path/to/project/components`: An alternative location for project specific NTS components. Should be an absolute or relative path, compared to `build.xml`.
 - `loadresources.exclude`: a relative path to a folder containing the fixtures to be excluded or to specific filenames. Multiple entries can be comma separated. `*` is accepted as a wildcard.
   ```

--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -16,6 +16,7 @@
     - commoncomonents.dir : The directory containing the common components.
     - lib.dir             : The directory where all build dependency's will be placed. It's a good idea to add this to
                             .gitignore.
+    - [components.dir]    : Optional - the directory containing the project components, relative to input.dir. Defaults to '_components'.
 
     Additionally, the following optional parameters may be used:
     - outputLevel: the verbosity level of the script output  
@@ -27,7 +28,7 @@
             build.properties: properties  
             InputFolder1/   : folder containing NTS files (may contain nested folders with more NTS files)
             InputFolder2/   : folder containing NTS files (may contain nested folders with more NTS files)
-            _components/    : the components specific for that project
+            _components/    : the components specific for that project - may be overridden using the components.dir parameter
             _reference/     : the fixtures for that project
     The input folder structure will be recreated in the output directory, together with the _reference folder.
 
@@ -42,6 +43,8 @@
     <!-- Make the directories passed as parameters absolute (except for output.dir.abs, because we first need to
          guarantee that this folder exists. This is done in check-input. -->
     <property name="input.dir.abs"            location="${input.dir}"/>
+    <property name="components.dir"           value="${input.dir}/_components"/>
+    <property name="components.dir.abs"       value="${components.dir}"/>
     <property name="commoncomponents.dir.abs" location="${commoncomponents.dir}"/>
     
     <!-- Try to read all project property's defined in build.properties -->
@@ -367,7 +370,6 @@
     
     <target name="build" depends="load, check-input, cleanBuildDir">
         <property name="reference.dir" location="${input.dir.abs}/_reference"/>
-        <property name="components.dir.abs" location="${input.dir.abs}/_components"/>
         
         <!-- Set default loadresources.exclude to nothing -->
         <property name="loadresources.exclude" value=""/>

--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -43,8 +43,8 @@
     <!-- Make the directories passed as parameters absolute (except for output.dir.abs, because we first need to
          guarantee that this folder exists. This is done in check-input. -->
     <property name="input.dir.abs"            location="${input.dir}"/>
-    <property name="components.dir"           value="${input.dir}/_components"/>
-    <property name="components.dir.abs"       value="${components.dir}"/>
+    <property name="components.dir"           location="${input.dir}/_components"/>
+    <property name="components.dir.abs"       location="${components.dir}"/>
     <property name="commoncomponents.dir.abs" location="${commoncomponents.dir}"/>
     
     <!-- Try to read all project property's defined in build.properties -->


### PR DESCRIPTION
... to work again as documented. In addition, remove the reference.dir parameter alltogether, as this cannot really work in relation to how Touchstone works.