### PR TITLE
HIT-21: Make creating additional targets work when there are subdirs in an input folder

### DIFF
--- a/generate/README.md
+++ b/generate/README.md
@@ -257,7 +257,7 @@ The following optional parameters may be used:
   targets.additional=Cert-with-setup
   ```
   The TestScript resources can use the `nts:in-targets` to define which element should be included in a target (see above). Multiple extra targets may be separated using comma's.
-  Note: additional targets may only be defined on input folders, not on subfolders. If there are subfolders in the input folder, each variant of the input folder will contain the full set of input folders (but with slightly different content, of course).  
+  Note: additional targets may only be defined on input folders, not on subfolders. If there are subfolders in the input folder, each variant of the input folder will contain the full set of subfolders (but with slightly different content, of course).  
 - `version.addition`: a string that will be added verbatim to the value in the `TestScript.version` from the input file. If this element is absent, it will be populated with this value. 
 
 ### Building multiple projects

--- a/generate/README.md
+++ b/generate/README.md
@@ -257,7 +257,8 @@ The following optional parameters may be used:
   targets.additional=Cert-with-setup
   ```
   The TestScript resources can use the `nts:in-targets` to define which element should be included in a target (see above). Multiple extra targets may be separated using comma's.
-- `version.addition`: a string that will be added verbatim to the value in the `TestScript.version` from the input file. If this element is absent, it will be populated with this value.
+  Note: additional targets may only be defined on input folders, not on subfolders. If there are subfolders in the input folder, each variant of the input folder will contain the full set of input folders (but with slightly different content, of course).  
+- `version.addition`: a string that will be added verbatim to the value in the `TestScript.version` from the input file. If this element is absent, it will be populated with this value. 
 
 ### Building multiple projects
 

--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -420,6 +420,19 @@
                                         </path>
                                         <map from="${input.dir.abs}" to=""/>
                                     </pathconvert>
+                                    
+                                    <!-- Now extract the root dir of the relative path, where additional targets may be
+                                         defined, and any subpaths following it. -->
+                                    <propertyregex property="nts.file.reldir.root" override="true"
+                                        input="${nts.file.reldir}"
+                                        regexp="(\/[^\/]+)\/"
+                                        select="\1"
+                                        defaultValue="${nts.file.reldir}"/>
+                                    <propertyregex property="nts.file.reldir.leaf" override="true"
+                                        input="${nts.file.reldir}"
+                                        regexp="\/[^\/]+(\/.*)"
+                                        select="\1"
+                                        defaultValue=""/>
                                     <if>
                                         <!-- The default target -->
                                         <equals arg1="@{target.dir}" arg2="#default"/>
@@ -431,18 +444,20 @@
                                         </then>
                                         <elseif>
                                             <!-- An extra defined target -->
-                                            <contains string="/@{target.dir}" substring="${nts.file.reldir}"/>
+                                            <contains string="/@{target.dir}" substring="${nts.file.reldir.root}"/>
                                             <then>
                                                 <sequential>
                                                     <!-- Extract the target name from the relative path name -->
+                                                    <var name="target" unset="true"/>
                                                     <pathconvert property="target" targetos="unix">
                                                         <path location="/@{target.dir}"/>
-                                                        <map from="${nts.file.reldir}-" to=""/>
-                                                        <map from="c:${nts.file.reldir}-" to=""/>
+                                                        <map from="${nts.file.reldir.root}-" to=""/>
+                                                        <map from="c:${nts.file.reldir.root}-" to=""/>
                                                     </pathconvert>
+                                                    <echo message="/@{target.dir} - ${nts.file.reldir.root} - ${target}"/>
                                                     <transform-NTS-file 
                                                         nts.file="@{nts.file}"
-                                                        output.dir="${output.dir.abs}/@{target.dir}" 
+                                                        output.dir="${output.dir.abs}/@{target.dir}${nts.file.reldir.leaf}" 
                                                         references.file="${references.file}"
                                                         target="${target}"/>
                                                 </sequential>


### PR DESCRIPTION
This change fixes a long-standing request where additional targets can be built in the presence of subfolders underneath the input folder.
However, this PR _also_ fixes a bug where it turned out to be impossible to specifiy more than one additional target. This is needed for https://github.com/Nictiz/Nictiz-STU3-testscripts-src/pull/127.