### PR TITLE
FHIR R4

### DIFF
--- a/generate/README.md
+++ b/generate/README.md
@@ -122,9 +122,11 @@ If the `description` parameter is omitted when including this component, the lat
 
 ### Fixtures, profiles and rules
 
-For fixtures, profiles and rules, custom elements have been made that are a bit more concise than their FHIR equivalents.
+### Defining fixtures, profiles and rules
+
+Fixtures, profiles and rules all have te be declared in a TestScript before they can be used in a test. Custom elements have been made that are a bit more concise than their FHIR equivalents.
   
-Fixtures and rules can be defined using:
+Fixtures and rules may be declared using:
 
 ```xml
 <nts:fixture id=".." href=".."/>
@@ -133,12 +135,44 @@ Fixtures and rules can be defined using:
 
 `href` is considered to be relative to a predefined fixtures folder. It defaults to the "_reference" folder directly beneath the project-folder. See the section on building to set an alternate location. All fixtures and rules in the "_reference"-folder are copied to the output folder.
 
-A LoadResources script is generated for all fixtures in the "_reference"-folder. See the section on building on how to exclude files and/or folders from being added the LoadResources script. 
-
-Profiles may be defined using:
+Profiles may be declared using:
 
 ```xml
 <nts:profile id=".." value=".."/>
+```
+
+#### Fixtures
+
+A LoadResources script is generated for all fixtures in the "_reference"-folder. See the section on building on how to exclude files and/or folders from being added the LoadResources script. 
+
+#### Using rules
+
+Once a rule is declared, it may be used in an `<assert>` using the same tag with only the `id` attribute set. Optional parameters to the rule are passed as attributes or using the `<nts:with-param>` tag, similar to how it is done with `<nts:include/>`: 
+
+```xml
+<nts:rule id=".."
+  param1="value1"
+  param2="value2" />
+```
+
+is equivalent to:
+
+```xml
+<nts:rule id="..">
+  <nts:with-param name="param1" value="value1"/>
+  <nts:with-param name="param2" value="value2"/>  
+</nts:rule>
+```
+
+It is also possible implicitly declare the rule when it is used by adding the `href` attribute here, e.g.:
+```xml
+<assert>
+  ..
+  <nts:rule id=".." href=".."
+    param1="value1"
+    param2="value2" />
+  ..
+</assert>  
 ```
 
 ### Patient token and date T

--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -416,7 +416,10 @@
                                     <dirname property="nts.file.dir" file="@{nts.file}"/>
                                     <pathconvert property="nts.file.reldir" targetos="unix">
                                         <path>
-                                            <dirset dir="${nts.file.dir}"/>
+                                            <dirset dir="${nts.file.dir}">
+                                                <!-- If a subdirectory is present next to NTS-files, an error occurs, because dirset returns current ánd subdirectories in one property. Therefore: exclude subdirs. -->
+                                                <exclude name="*/**/"/>
+                                            </dirset>
                                         </path>
                                         <map from="${input.dir.abs}" to=""/>
                                     </pathconvert>

--- a/generate/xslt/collectReferences.xsl
+++ b/generate/xslt/collectReferences.xsl
@@ -37,8 +37,9 @@
         <xsl:text>&#xA;</xsl:text>
         
         <xsl:variable name="rules" as="xs:string*">
-            <xsl:for-each select="//f:rule[f:resource]">
-                <xsl:value-of select="substring-after(f:resource/f:reference/@value, $includesDir)"/>        
+            <xsl:for-each select="//f:extension[@url = 'http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-rule']">
+                <xsl:value-of select="substring-after(f:extension[@url = 'path']/f:valueString/@value, $includesDir)"/>
+                
             </xsl:for-each>
             <xsl:for-each select="tokenize($additionalRules, ';')">
                 <xsl:if test="string-length(.) &gt; 0">

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -129,7 +129,7 @@
                             <accept value="xml"/>
                             <contentType value="xml"/>
                             <encodeRequestUrl value="true"/>
-                            <params value="/$purge"/>
+                            <params value="{tokenize(substring-before(base-uri(), '-token.xml'), '/')[last()]}/$purge"/>
                             <requestHeader>
                                 <field value="Authorization"/>
                                 <value value="{f:id/@value}"/>

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -64,7 +64,7 @@
         <xsl:choose>
             <xsl:when test="$fixtures">
         <!-- Write out the TestScript resource -->
-        <TestScript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhir" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/testscript.xsd">
+        <TestScript xmlns="http://hl7.org/fhir">
             <id value="resources-purgecreateupdate-xml"/>
             <url value="http://nictiz.nl/fhir/TestScript/load-resources-purgecreateupdate-xml"/>
             <name value="Load Test Resources - Purge Create Update - XML"/>
@@ -88,6 +88,8 @@
                     <xsl:call-template name="generateFixtureId"/>
                 </xsl:variable>
                 <fixture id="{$fixtureId}">
+                    <autocreate value="false"/>
+                    <autodelete value="false"/>
                     <resource>
                         <reference value="{replace(document-uri(ancestor::node()), $referenceDirAsUrl, $referenceBaseSanitized)}"/>
                     </resource>
@@ -126,6 +128,7 @@
                             <resource value="Patient"/>
                             <accept value="xml"/>
                             <contentType value="xml"/>
+                            <encodeRequestUrl value="true"/>
                             <params value="/$purge"/>
                             <requestHeader>
                                 <field value="Authorization"/>
@@ -139,6 +142,7 @@
                                 value="Confirm that the returned HTTP status is 200(OK) or 204(No Content)"/>
                             <operator value="in"/>
                             <responseCode value="200,204"/>
+                            <warningOnly value="false"/>
                         </assert>
                     </action>
                 </xsl:for-each>
@@ -162,6 +166,7 @@
                             <resource value="{local-name(.)}"/>
                             <accept value="xml"/>
                             <contentType value="xml"/>
+                            <encodeRequestUrl value="true"/>
                             <params value="/${{{$fixtureId}-id}}"/>
                             <requestHeader>
                                 <field value="Authorization"/>
@@ -178,6 +183,7 @@
                             <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
                             <operator value="in"/>
                             <responseCode value="200,201"/>
+                            <warningOnly value="false"/>
                         </assert>
                     </action>
                 </xsl:for-each>

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -153,6 +153,8 @@
                 <name value="Step1-LoadTestResourceCreate"/>
                 <description value="Load test resources using the update (PUT) operation of the target FHIR server for use in testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
                 <xsl:for-each select="$fixtures">
+                    <!-- Load Patient resources first to make sure WildFHIR indexes data in the right order to use patient.identifier searches. -->
+                    <xsl:sort data-type="number" order="ascending" select="(number(local-name() = 'Patient') * 1) + (number(not(local-name() = 'Patient')) * 2)"/>
                     <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
                     <xsl:variable name="fixtureId">
                         <xsl:call-template name="generateFixtureId"/>

--- a/generate/xslt/generateTestScript.xsl
+++ b/generate/xslt/generateTestScript.xsl
@@ -282,7 +282,7 @@
         </xsl:copy>
     </xsl:template>
     
-    <!--Add TouchStone assert-stopTestOnFail extension by default.-->
+    <!--Add TouchStone assert-stopTestOnFail extension and warningOnly flag by default.-->
     <xsl:template match="f:TestScript/f:test/f:action/f:assert" mode="filter">
         <xsl:copy>
             <xsl:apply-templates select="@*" mode="#current"/>
@@ -300,6 +300,9 @@
                 </xsl:otherwise>
             </xsl:choose>
             <xsl:apply-templates select="node()" mode="#current"/>
+            <xsl:if test="not(f:warningOnly)">
+                <warningOnly value="false"/>
+            </xsl:if>
         </xsl:copy>
     </xsl:template>
     

--- a/generate/xslt/generateTestScript.xsl
+++ b/generate/xslt/generateTestScript.xsl
@@ -260,20 +260,25 @@
         </xsl:attribute>
     </xsl:template>
     
-    <!--Add the Accept header, if necessary-->
+    <!--Add the Accept header and encodeRequestUrl, if necessary-->
     <xsl:template match="f:TestScript/f:test/f:action/f:operation" mode="filter">
         <xsl:param name="scenario" tunnel="yes"/>
         <xsl:param name="expectedResponseFormat" tunnel="yes"/>
         
         <!--All elements that can exist before the accept element following the FHIR spec.-->
         <xsl:variable name="pre-accept" select="('type','resource','label','description')"/>
+        <xsl:variable name="pre-encodeRequestUrl" select="('contentType','destination','accept')"/>
         <xsl:copy>
             <xsl:apply-templates select="@*" mode="#current"/>
             <xsl:apply-templates select="f:*[local-name()=$pre-accept]" mode="#current"/>
             <xsl:if test="$scenario='server' and not(f:accept) and $expectedResponseFormat != ''">
                 <accept value="{lower-case($expectedResponseFormat)}"/>
             </xsl:if>
-            <xsl:apply-templates select="f:*[not(local-name()=$pre-accept)]" mode="#current"/>
+            <xsl:apply-templates select="f:*[local-name()=$pre-encodeRequestUrl]" mode="#current"/>
+            <xsl:if test="not(f:encodeRequestUrl)">
+                <encodeRequestUrl value="true"/>
+            </xsl:if>
+            <xsl:apply-templates select="f:*[not(local-name()=$pre-accept or local-name()=$pre-encodeRequestUrl)]" mode="#current"/>
         </xsl:copy>
     </xsl:template>
     

--- a/generate/xslt/generateTestScript.xsl
+++ b/generate/xslt/generateTestScript.xsl
@@ -419,6 +419,7 @@
     
     <!-- Expand a nts:rule element -->
     <xsl:template match="nts:rule[@id and @href]" mode="expand">
+        <!-- https://touchstone.aegis.net/touchstone/userguide/html/testscript-authoring/rule-authoring/basics.html -->
         <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-rule">
             <extension url="ruleId">
                 <valueId value="{@id}"/>

--- a/generate/xslt/generateTestScript.xsl
+++ b/generate/xslt/generateTestScript.xsl
@@ -105,7 +105,9 @@
                         <xsl:message terminate="yes" select="concat('Encountered different rules using the id ''', f:extension[@url = 'ruleId']/f:valueId/@value, '''')"/>
                     </xsl:if>
                 </xsl:for-each>
-                <xsl:copy-of select="current-group()[1]"/>
+                <xsl:apply-templates select="current-group()[1]" mode="filter">
+                    <xsl:with-param name="doCopy" select="true()"/>
+                </xsl:apply-templates>
             </xsl:for-each-group>
             
             <xsl:apply-templates select="f:extension[not(@url = 'http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-rule')] | f:modifierExtension" mode="#current"/>
@@ -169,7 +171,9 @@
                         <xsl:message terminate="yes" select="concat('Encountered different fixture inclusions using the same id ''', @id, '''')"/>
                     </xsl:if>
                 </xsl:for-each>
-                <xsl:copy-of select="current-group()[1]"/>
+                <xsl:apply-templates select="current-group()[1]" mode="filter">
+                    <xsl:with-param name="doCopy" select="true()"/>
+                </xsl:apply-templates>
             </xsl:for-each-group>
             <xsl:for-each-group select="$profiles" group-by="@id">
                 <xsl:for-each select="subsequence(current-group(), 2)">
@@ -177,7 +181,9 @@
                         <xsl:message terminate="yes" select="concat('Encountered different profile declarations using the id ''', @id, '''')"/>
                     </xsl:if>
                 </xsl:for-each>
-                <xsl:copy-of select="current-group()[1]"/>
+                <xsl:apply-templates select="current-group()[1]" mode="filter">
+                    <xsl:with-param name="doCopy" select="true()"/>
+                </xsl:apply-templates>
             </xsl:for-each-group>
             <xsl:for-each-group select="$variables" group-by="f:name/@value">
                 <xsl:for-each select="subsequence(current-group(), 2)">
@@ -185,17 +191,40 @@
                         <xsl:message terminate="yes" select="concat('Encountered different variables using the name ''', f:name/@value, '''')"/>
                     </xsl:if>
                 </xsl:for-each>
-                <xsl:copy-of select="current-group()[1]"/>
+                <xsl:apply-templates select="current-group()[1]" mode="filter">
+                    <xsl:with-param name="doCopy" select="true()"/>
+                </xsl:apply-templates>
             </xsl:for-each-group>
             <xsl:apply-templates select="f:setup | f:test | f:teardown" mode="#current"/>
         </xsl:copy>
     </xsl:template>
     
-    <!-- Silence fixture, profile, variable and rule elements, because they are already handled elsewhere -->
-    <xsl:template match="f:TestScript//f:fixture" mode="filter" />
-    <xsl:template match="f:TestScript//f:profile" mode="filter" />
-    <xsl:template match="f:TestScript//f:variable" mode="filter" />
-    <xsl:template match="f:TestScript//f:extension[@url = 'http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-rule']" mode="filter" />
+    <!-- Fixture, profile, variable and rule elements:
+        Silence by default, because they are already handled elsewhere, but copied if explicitly intended with param doCopy -->
+    <xsl:template match="f:TestScript//f:fixture" mode="filter">
+        <xsl:param name="doCopy" select="false()"/>
+        <xsl:if test="$doCopy">
+            <xsl:next-match/>
+        </xsl:if>
+    </xsl:template>
+    <xsl:template match="f:TestScript//f:profile" mode="filter">
+        <xsl:param name="doCopy" select="false()"/>
+        <xsl:if test="$doCopy">
+            <xsl:next-match/>
+        </xsl:if>
+    </xsl:template>
+    <xsl:template match="f:TestScript//f:variable" mode="filter">
+        <xsl:param name="doCopy" select="false()"/>
+        <xsl:if test="$doCopy">
+            <xsl:next-match/>
+        </xsl:if>
+    </xsl:template>
+    <xsl:template match="f:TestScript//f:extension[@url = 'http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-rule']" mode="filter">
+        <xsl:param name="doCopy" select="false()"/>
+        <xsl:if test="$doCopy">
+            <xsl:next-match/>
+        </xsl:if>
+    </xsl:template>
     
     <!-- Silence rule use elements that have been produced in the wrong place as a side effect of the declaration element --> 
     <xsl:template match="f:TestScript//f:extension[@url = 'http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-rule'][not(parent::f:assert)]" mode="filter" />

--- a/generate/xslt/generateTestScript.xsl
+++ b/generate/xslt/generateTestScript.xsl
@@ -250,6 +250,7 @@
         <xsl:copy>
             <xsl:apply-templates select="@*" mode="#current"/>
             <xsl:choose>
+                <xsl:when test="f:extension/@url = 'http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail'"/>
                 <xsl:when test="@nts:stopTestOnFail='true'">
                     <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                         <valueBoolean value="true"/>


### PR DESCRIPTION
For release 1.10.0

Changelog:
- Migrate TestScript version to FHIR 4.0.1
-- Add elements where minimum cardinality is changed to 1 in TestScript specification
-- Change rules from core element to TouchStone extension
- Reorder LoadResources to first index the Patient resource. This ensures that all References to this Patient are indexed, which is necessary for searching WildFHIR on .subject. _Note:_ this leads to the question if the order in LoadResources matters for other References that are to be searched on, but no problems have surfaced with this yet ...
- Add Patient `id` to $purge in LoadResources to function without Bearer token. Still works if Bearer token is included.
- Fix where a subdirectory present next to NTS-files would lead to the build failing.
- Fix where stopTestOnFail extension was added if it was already present.

TODO:
- Edit changelog in README (the changes themselves do not require any README changes as far as I am aware)
- Test if migrating all TestScripts to FHIR 4.0.1 lead to errors in the tests that use STU3 packages/fixtures