### PR TITLE
contentValidation

### DIFF
--- a/contentValidation/test/in/dwv-Transaction-Scenario-1.xml
+++ b/contentValidation/test/in/dwv-Transaction-Scenario-1.xml
@@ -1,0 +1,138 @@
+<Bundle xmlns="http://hl7.org/fhir">
+    <type value="transaction"/>
+    <entry>
+        <fullUrl value="${UUID-ST}"/>
+        <resource>
+            <Communication>
+                <meta>
+                    <profile value="http://nictiz.nl/fhir/StructureDefinition/dwv-PatientCorrectionsCommunication"/>
+                </meta>
+                <identifier>
+                    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.​130.1.40"/>
+                    <value value="31dba9d5-109e-4baf-a3b2-6cfd457a3ba1"/>
+                </identifier>
+                <status value="completed"/>
+                <category>
+                    <coding>
+                        <system
+                            value="https://hl7.org/fhir/uv/fhir-patient-correction/CodeSystem/PatientCorrectionCommunicationTypes"/>
+                        <code value="medRecCxReq"/>
+                        <display value="Correction request by the Patient or RelatedPerson"/>
+                    </coding>
+                </category>
+                <subject>
+                    <reference value="urn:uuid:7ea9a04a-9276-4b53-88ca-9eb0910b6c88"/>
+                    <type value="Patient"/>
+                    <display value="Johan XXX_Helleman"/>
+                </subject>
+                <topic>
+                    <text value="Telefoonnummer wijzigen"/>
+                </topic>
+                <sent value="${DATE, T, D, -0}T07:35:00Z"/>
+                <recipient>
+                    <reference value="urn:uuid:a11d5b56-6460-4dfd-85e9-bb4bb961a864"/>
+                    <type value="Organization"/>
+                    <display value="Test Medisch Centrum"/>
+                </recipient>
+                <sender>
+                    <reference value="urn:uuid:7ea9a04a-9276-4b53-88ca-9eb0910b6c88"/>
+                    <type value="Patient"/>
+                    <display value="Johan XXX_Helleman"/>
+                </sender>
+                <payload>
+                    <contentString value="Ik heb in mijn dossier gezien dat mijn telefoonnummer niet klopt. Dit wil ik graag gewijzigd hebben. Mijn telefoonnummer is 06-12345678."/>
+                </payload>
+            </Communication>
+        </resource>
+        <request>
+            <method value="POST"/>
+            <url value="Communication"/>
+        </request>
+    </entry>
+    <entry>
+        <fullUrl value="urn:uuid:7ea9a04a-9276-4b53-88ca-9eb0910b6c88"/>
+        <resource>
+            <Patient>
+            <meta>
+                <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient"/>
+            </meta>
+            <identifier>
+                <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.​130.1.135"/>
+                <value value="1285290"/>
+            </identifier>
+            <name>
+                <use value="official"/>
+                <text value="Johan XXX_Helleman"/>
+                <family value="XXX_Helleman">
+                    <extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
+                        <valueString value="XXX_Helleman"/>
+                    </extension>
+                </family>
+                <given value="Johan">
+                    <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+                        <valueCode value="BR"/>
+                    </extension>
+                </given>
+            </name>
+            <gender value="male">
+                <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-CodeSpecification">
+                    <valueCodeableConcept>
+                        <coding>
+                            <system value="http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender"/>
+                            <code value="M"/>
+                            <display value="Man"/>
+                        </coding>
+                    </valueCodeableConcept>
+                </extension>
+            </gender>
+            <birthDate value="1964-07-25"/>
+            <address>
+                <line value="Knolweg 1000">
+                    <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+                        <valueString value="Knolweg"/>
+                    </extension>
+                    <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+                        <valueString value="1000"/>
+                    </extension>
+                </line>
+                <city value="Stitswerd"/>
+                <postalCode value="9999XA"/>
+                <country value="NLD">
+                    <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-CodeSpecification">
+                        <valueCodeableConcept>
+                            <coding>
+                                <system value="urn:oid:2.16.840.1.113883.2.4.4.16.34"/>
+                                <code value="6030"/>
+                                <display value="Nederland"/>
+                            </coding>
+                        </valueCodeableConcept>
+                    </extension>
+                </country>
+            </address>
+            </Patient>
+        </resource>
+        <request>
+            <method value="POST"/>
+            <url value="Patient"/>
+        </request>
+    </entry>
+    <entry>
+        <fullUrl value="urn:uuid:a11d5b56-6460-4dfd-85e9-bb4bb961a864"/>
+        <resource>
+            <Organization>
+            <meta>
+                <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider-Organization"/>
+            </meta>
+            <identifier>
+                <system value="http://fhir.nl/fhir/NamingSystem/ura"/>
+                <value value="12341234"/>
+            </identifier>
+            <name value="Test Medisch Centrum"/>
+            </Organization>
+        </resource>
+        <request>
+            <method value="POST"/>
+            <url value="Organization"/>
+        </request>
+    </entry>
+</Bundle>

--- a/contentValidation/test/in/exampleout-dwv-Transaction-Scenario-1.xml
+++ b/contentValidation/test/in/exampleout-dwv-Transaction-Scenario-1.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="dwv-Bundle-Scenario-1" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/dwv-Bundle-Scenario-1" />
+  <name value="DwvBundleScenario1" />
+  <title value="dwv Bundle Scenario 1" />
+  <status value="draft" />
+  <experimental value="true" />
+  <description value="Constrained profile for qualification purposes. Not suited for implementation." />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Bundle" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Bundle" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Bundle.type">
+      <path value="Bundle.type" />
+      <fixedCode value="transaction" />
+    </element>
+    <element id="Bundle.entry">
+      <path value="Bundle.entry" />
+      <slicing>
+        <discriminator>
+          <type value="profile" />
+          <path value="resource" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Bundle.entry.link"><!-- Forge artifact? -->
+      <path value="Bundle.entry.link" />
+      <contentReference value="http://hl7.org/fhir/StructureDefinition/Bundle#Bundle.link" />
+    </element>
+    <element id="Bundle.entry:communication">
+      <path value="Bundle.entry" />
+      <sliceName value="communication" />
+      <min value="1" />
+      <max value="1" />
+    </element>
+    <element id="Bundle.entry:communication.link"><!-- Forge artifact? -->
+      <path value="Bundle.entry.link" />
+      <contentReference value="http://hl7.org/fhir/StructureDefinition/Bundle#Bundle.link" />
+    </element>
+    <element id="Bundle.entry:communication.resource">
+      <path value="Bundle.entry.resource" />
+      <min value="1" />
+      <type>
+        <code value="Resource" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/dwv-PatientCorrectionsCommunication" />
+      </type>
+    </element>
+    <element id="Bundle.entry:communication.resource.identifier.system">
+      <path value="Bundle.entry.resource.identifier.system" />
+      <min value="1" />
+    </element>
+    <element id="Bundle.entry:communication.resource.identifier.value">
+      <path value="Bundle.entry.resource.identifier.value" />
+      <min value="1" />
+    </element>
+    <element id="Bundle.entry:communication.resource.category.coding">
+      <path value="Bundle.entry.resource.category.coding" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="code" />
+        </discriminator>
+        <discriminator>
+          <type value="value" />
+          <path value="system" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <min value="1" />
+    </element>
+    <element id="Bundle.entry:communication.resource.category.coding:requiredCoding">
+      <path value="Bundle.entry.resource.category.coding" />
+      <sliceName value="requiredCoding" />
+      <min value="1" />
+      <max value="1" />
+    </element>
+    <element id="Bundle.entry:communication.resource.category.coding:requiredCoding.system">
+      <path value="Bundle.entry.resource.category.coding.system" />
+      <min value="1" />
+      <fixedUri value="https://hl7.org/fhir/uv/fhir-patient-correction/CodeSystem/PatientCorrectionCommunicationTypes" />
+    </element>
+    <element id="Bundle.entry:communication.resource.category.coding:requiredCoding.code">
+      <path value="Bundle.entry.resource.category.coding.code" />
+      <min value="1" />
+      <fixedCode value="medRecCxReq" />
+    </element>
+    <element id="Bundle.entry:communication.resource.category.coding:requiredCoding.display">
+      <path value="Bundle.entry.resource.category.coding.display" />
+      <min value="1" />
+    </element>
+    <element id="Bundle.entry:communication.resource.subject">
+      <path value="Bundle.entry.resource.subject" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient" />
+      </type>
+    </element>
+    <element id="Bundle.entry:communication.resource.subject.reference">
+      <path value="Bundle.entry.resource.subject.reference" />
+      <min value="1" />
+    </element>
+    <element id="Bundle.entry:communication.resource.subject.type">
+      <path value="Bundle.entry.resource.subject.type" />
+      <min value="1" />
+      <fixedUri value="Patient" />
+    </element>
+    <element id="Bundle.entry:communication.resource.subject.display">
+      <path value="Bundle.entry.resource.subject.display" />
+      <min value="1" />
+    </element>
+    <element id="Bundle.entry:communication.resource.topic.text">
+      <path value="Bundle.entry.resource.topic.text" />
+      <fixedString value="Telefoonnummer wijzigen" />
+    </element>
+    <element id="Bundle.entry:communication.resource.recipient">
+      <path value="Bundle.entry.resource.recipient" />
+      <!-- Don't think we can explicitly say so. Is this forbidden? Then it should be enforced by constraints? -->
+      <max value="1" />
+    </element>
+    <element id="Bundle.entry:communication.resource.recipient:healthcareProvider">
+      <path value="Bundle.entry.resource.recipient" />
+      <sliceName value="healthcareProvider" />
+    </element>
+    <element id="Bundle.entry:communication.resource.recipient:healthcareProvider.reference">
+      <path value="Bundle.entry.resource.recipient.reference" />
+      <min value="1" />
+    </element>
+    <element id="Bundle.entry:communication.resource.recipient:healthcareProvider.type">
+      <path value="Bundle.entry.resource.recipient.type" />
+      <min value="1" />
+      <fixedUri value="Organization" />
+    </element>
+    <element id="Bundle.entry:communication.resource.recipient:healthcareProvider.display">
+      <path value="Bundle.entry.resource.recipient.display" />
+      <min value="1" />
+    </element>
+    <element id="Bundle.entry:communication.resource.recipient:healthProfessional">
+      <path value="Bundle.entry.resource.recipient" />
+      <sliceName value="healthProfessional" />
+      <!-- Don't think we can explicitly say so. Is this forbidden? Then it should be enforced by constraints? -->
+      <max value="0" />
+    </element>
+    <element id="Bundle.entry:communication.resource.sender">
+      <path value="Bundle.entry.resource.sender" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient" />
+      </type>
+    </element>
+    <element id="Bundle.entry:communication.resource.sender.reference">
+      <path value="Bundle.entry.resource.sender.reference" />
+      <min value="1" />
+    </element>
+    <element id="Bundle.entry:communication.resource.sender.type">
+      <path value="Bundle.entry.resource.sender.type" />
+      <min value="1" />
+      <fixedUri value="Patient" />
+    </element>
+    <element id="Bundle.entry:communication.resource.sender.display">
+      <path value="Bundle.entry.resource.sender.display" />
+      <min value="1" />
+    </element>
+    <element id="Bundle.entry:communication.resource.payload.content[x]">
+      <path value="Bundle.entry.resource.payload.content[x]" />
+      <fixedString value="Ik heb in mijn dossier gezien dat mijn telefoonnummer niet klopt. Dit wil ik graag gewijzigd hebben. Ik zou graag teruggebeld willen worden." />
+    </element>
+  </differential>
+</StructureDefinition>

--- a/contentValidation/test/in/snapshot-DwvPatientCorrectionsCommunication.xml
+++ b/contentValidation/test/in/snapshot-DwvPatientCorrectionsCommunication.xml
@@ -1,0 +1,2254 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="dwv-PatientCorrectionsCommunication" />
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-category">
+    <valueString value="Clinical.Request &amp;amp; Response" />
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-security-category">
+    <valueCode value="patient" />
+  </extension>
+  <url value="http://nictiz.nl/fhir/StructureDefinition/dwv-PatientCorrectionsCommunication" />
+  <version value="1.0.0" />
+  <name value="DwvPatientCorrectionsCommunication" />
+  <title value="dwv PatientCorrectionsCommunication" />
+  <status value="active" />
+  <publisher value="Nictiz" />
+  <contact>
+    <name value="Nictiz" />
+    <telecom>
+      <system value="url" />
+      <value value="https://www.nictiz.nl" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="A Communication resource as used within the Patient Corrections (Dutch: Dossierwijzigingsverzoek) information standard. *NOTE*: this profile is inspired by the https://hl7.org/fhir/uv/fhir-patient-correction/StructureDefinition/patient-correction-communication profile. However, different choices have been made on several key points in order to align with other FHIR materials in the Dutch realm. Therefore, this is not a derived profile. This profile is based on FHIR version 4.0.1, which was the latest R4 version at the moment of creation." />
+  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise." />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="workflow" />
+    <uri value="http://hl7.org/fhir/workflow" />
+    <name value="Workflow Pattern" />
+  </mapping>
+  <mapping>
+    <identity value="w5" />
+    <uri value="http://hl7.org/fhir/fivews" />
+    <name value="FiveWs Pattern Mapping" />
+  </mapping>
+  <mapping>
+    <identity value="rim" />
+    <uri value="http://hl7.org/v3" />
+    <name value="RIM Mapping" />
+  </mapping>
+  <mapping>
+    <identity value="art-decor-dossierwijzigingsverzoek" />
+    <uri value="https://decor.nictiz.nl/pub/dossierwijzigingsverzoek/dwv-html-20220826T185150/ds-2.16.840.1.113883.2.4.3.11.60.130.1.1-2021-11-17T165644.html" />
+    <name value="ART-DECOR-dataset Dossierwijzigingsverzoek" />
+  </mapping>
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Communication" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Communication" />
+  <derivation value="constraint" />
+  <snapshot>
+    <element id="Communication">
+      <path value="Communication" />
+      <short value="A record of information transmitted from a sender to a receiver" />
+      <definition value="An occurrence of information being transmitted; e.g. an alert that was sent to a responsible provider, a public health agency that was notified about a reportable condition." />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="Communication" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <constraint>
+        <key value="dom-2" />
+        <severity value="error" />
+        <human value="If the resource is contained in another resource, it SHALL NOT contain nested Resources" />
+        <expression value="contained.contained.empty()" />
+        <xpath value="not(parent::f:contained and f:contained)" />
+        <source value="http://hl7.org/fhir/StructureDefinition/DomainResource" />
+      </constraint>
+      <constraint>
+        <key value="dom-4" />
+        <severity value="error" />
+        <human value="If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated" />
+        <expression value="contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()" />
+        <xpath value="not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))" />
+        <source value="http://hl7.org/fhir/StructureDefinition/DomainResource" />
+      </constraint>
+      <constraint>
+        <key value="dom-3" />
+        <severity value="error" />
+        <human value="If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource" />
+        <expression value="contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()" />
+        <xpath value="not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))" />
+        <source value="http://hl7.org/fhir/StructureDefinition/DomainResource" />
+      </constraint>
+      <constraint>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice">
+          <valueBoolean value="true" />
+        </extension>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation">
+          <valueMarkdown value="When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time." />
+        </extension>
+        <key value="dom-6" />
+        <severity value="warning" />
+        <human value="A resource should have narrative for robust management" />
+        <expression value="text.`div`.exists()" />
+        <xpath value="exists(f:text/h:div)" />
+        <source value="http://hl7.org/fhir/StructureDefinition/DomainResource" />
+      </constraint>
+      <constraint>
+        <key value="dom-5" />
+        <severity value="error" />
+        <human value="If a resource is contained in another resource, it SHALL NOT have a security label" />
+        <expression value="contained.meta.security.empty()" />
+        <xpath value="not(exists(f:contained/*/f:meta/f:security))" />
+        <source value="http://hl7.org/fhir/StructureDefinition/DomainResource" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="Entity. Role, or Act" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event" />
+      </mapping>
+    </element>
+    <element id="Communication.id">
+      <path value="Communication.id" />
+      <short value="Logical id of this artifact" />
+      <definition value="The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes." />
+      <comment value="The only time that a resource does not have an id is when it is being submitted to the server using a create operation." />
+      <min value="0" />
+      <max value="1" />
+      <base>
+        <path value="Resource.id" />
+        <min value="0" />
+        <max value="1" />
+      </base>
+      <type>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type">
+          <valueUrl value="string" />
+        </extension>
+        <code value="http://hl7.org/fhirpath/System.String" />
+      </type>
+      <isSummary value="true" />
+    </element>
+    <element id="Communication.meta">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.meta" />
+      <short value="Metadata about the resource" />
+      <definition value="The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource." />
+      <min value="0" />
+      <max value="1" />
+      <base>
+        <path value="Resource.meta" />
+        <min value="0" />
+        <max value="1" />
+      </base>
+      <type>
+        <code value="Meta" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <isSummary value="true" />
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="N/A" />
+      </mapping>
+    </element>
+    <element id="Communication.implicitRules">
+      <path value="Communication.implicitRules" />
+      <short value="A set of rules under which this content was created" />
+      <definition value="A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc." />
+      <comment value="Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc." />
+      <min value="0" />
+      <max value="1" />
+      <base>
+        <path value="Resource.implicitRules" />
+        <min value="0" />
+        <max value="1" />
+      </base>
+      <type>
+        <code value="uri" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <isModifier value="true" />
+      <isModifierReason value="This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation" />
+      <isSummary value="true" />
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+    </element>
+    <element id="Communication.language">
+      <path value="Communication.language" />
+      <short value="Language of the resource content" />
+      <definition value="The base language in which the resource is written." />
+      <comment value="Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute)." />
+      <min value="0" />
+      <max value="1" />
+      <base>
+        <path value="Resource.language" />
+        <min value="0" />
+        <max value="1" />
+      </base>
+      <type>
+        <code value="code" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet">
+          <valueCanonical value="http://hl7.org/fhir/ValueSet/all-languages" />
+        </extension>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="Language" />
+        </extension>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding">
+          <valueBoolean value="true" />
+        </extension>
+        <strength value="preferred" />
+        <description value="A human language." />
+        <valueSet value="http://hl7.org/fhir/ValueSet/languages" />
+      </binding>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+    </element>
+    <element id="Communication.text">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.text" />
+      <short value="Text summary of the resource, for human interpretation" />
+      <definition value="A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it &quot;clinically safe&quot; for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety." />
+      <comment value="Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a &quot;text blob&quot; or where text is additionally entered raw or narrated and encoded information is added later." />
+      <alias value="narrative" />
+      <alias value="html" />
+      <alias value="xhtml" />
+      <alias value="display" />
+      <min value="0" />
+      <max value="1" />
+      <base>
+        <path value="DomainResource.text" />
+        <min value="0" />
+        <max value="1" />
+      </base>
+      <type>
+        <code value="Narrative" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="N/A" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="Act.text?" />
+      </mapping>
+    </element>
+    <element id="Communication.contained">
+      <path value="Communication.contained" />
+      <short value="Contained, inline Resources" />
+      <definition value="These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope." />
+      <comment value="This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels." />
+      <alias value="inline resources" />
+      <alias value="anonymous resources" />
+      <alias value="contained resources" />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="DomainResource.contained" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Resource" />
+      </type>
+      <mapping>
+        <identity value="rim" />
+        <map value="Entity. Role, or Act" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="N/A" />
+      </mapping>
+    </element>
+    <element id="Communication.extension">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <description value="Extensions are always sliced by (at least) url" />
+        <rules value="open" />
+      </slicing>
+      <short value="Additional content defined by implementations" />
+      <definition value="May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+      <comment value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+      <alias value="extensions" />
+      <alias value="user content" />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="DomainResource.extension" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Extension" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ext-1" />
+        <severity value="error" />
+        <human value="Must have either extensions or value[x], not both" />
+        <expression value="extension.exists() != value.exists()" />
+        <xpath value="exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/DomainResource" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="N/A" />
+      </mapping>
+    </element>
+    <element id="Communication.modifierExtension">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.modifierExtension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <description value="Extensions are always sliced by (at least) url" />
+        <rules value="open" />
+      </slicing>
+      <short value="Extensions that cannot be ignored" />
+      <definition value="May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.&#xA;&#xA;Modifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself)." />
+      <comment value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+      <requirements value="Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](extensibility.html#modifierExtension)." />
+      <alias value="extensions" />
+      <alias value="user content" />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="DomainResource.modifierExtension" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Extension" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ext-1" />
+        <severity value="error" />
+        <human value="Must have either extensions or value[x], not both" />
+        <expression value="extension.exists() != value.exists()" />
+        <xpath value="exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/DomainResource" />
+      </constraint>
+      <isModifier value="true" />
+      <isModifierReason value="Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them" />
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="N/A" />
+      </mapping>
+    </element>
+    <element id="Communication.identifier">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.identifier" />
+      <short value="Unique identifier" />
+      <definition value="Business identifiers assigned to this communication by the performer or other systems which remain constant as the resource is updated and propagates from server to server." />
+      <comment value="This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number." />
+      <requirements value="Allows identification of the communication as it is known by various participating systems and in a way that remains consistent across servers." />
+      <min value="1" />
+      <max value="*" />
+      <base>
+        <path value="Communication.identifier" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Identifier" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <isSummary value="true" />
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="v2" />
+        <map value="CX / EI (occasionally, more often EI maps to a resource id or a URL)" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="II - The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]" />
+      </mapping>
+      <mapping>
+        <identity value="servd" />
+        <map value="Identifier" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.identifier" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.identifier" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-40" />
+        <comment value="identifier" />
+      </mapping>
+    </element>
+    <element id="Communication.instantiatesCanonical">
+      <path value="Communication.instantiatesCanonical" />
+      <short value="Instantiates FHIR protocol or definition" />
+      <definition value="The URL pointing to a FHIR-defined protocol, guideline, orderset or other definition that is adhered to in whole or in part by this Communication." />
+      <comment value="see [Canonical References](references.html#canonical)" />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="Communication.instantiatesCanonical" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="canonical" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/PlanDefinition" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/ActivityDefinition" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Measure" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/OperationDefinition" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Questionnaire" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <isSummary value="true" />
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.instantiatesCanonical" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value=".outboundRelationship[typeCode=DEFN].target" />
+      </mapping>
+    </element>
+    <element id="Communication.instantiatesUri">
+      <path value="Communication.instantiatesUri" />
+      <short value="Instantiates external protocol or definition" />
+      <definition value="The URL pointing to an externally maintained protocol, guideline, orderset or other definition that is adhered to in whole or in part by this Communication." />
+      <comment value="This might be an HTML page, PDF, etc. or could just be a non-resolvable URI identifier." />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="Communication.instantiatesUri" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="uri" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <isSummary value="true" />
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.instantiatesUri" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value=".outboundRelationship[typeCode=DEFN].target" />
+      </mapping>
+    </element>
+    <element id="Communication.basedOn">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.basedOn" />
+      <short value="Request fulfilled by this communication" />
+      <definition value="An order, proposal or plan fulfilled in whole or in part by this Communication." />
+      <comment value="This must point to some sort of a 'Request' resource, such as CarePlan, CommunicationRequest, ServiceRequest, MedicationRequest, etc." />
+      <alias value="fulfills" />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="Communication.basedOn" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Resource" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ref-1" />
+        <severity value="error" />
+        <human value="SHALL have a contained resource if a local reference is provided" />
+        <expression value="reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))" />
+        <xpath value="not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Communication" />
+      </constraint>
+      <isSummary value="true" />
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.basedOn" />
+      </mapping>
+    </element>
+    <element id="Communication.partOf">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.partOf" />
+      <short value="Part of this action" />
+      <definition value="Part of this action." />
+      <comment value="References SHALL be a reference to an actual FHIR resource, and SHALL be resolveable (allowing for access control, temporary unavailability, etc.). Resolution can be either by retrieval from the URL, or, where applicable by resource type, by treating an absolute reference as a canonical URL and looking it up in a local registry/repository." />
+      <alias value="container" />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="Communication.partOf" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Resource" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ref-1" />
+        <severity value="error" />
+        <human value="SHALL have a contained resource if a local reference is provided" />
+        <expression value="reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))" />
+        <xpath value="not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Communication" />
+      </constraint>
+      <isSummary value="true" />
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.partOf" />
+      </mapping>
+    </element>
+    <element id="Communication.inResponseTo">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.inResponseTo" />
+      <short value="Reply to" />
+      <definition value="Prior communication that this communication is in response to." />
+      <comment value="References SHALL be a reference to an actual FHIR resource, and SHALL be resolveable (allowing for access control, temporary unavailability, etc.). Resolution can be either by retrieval from the URL, or, where applicable by resource type, by treating an absolute reference as a canonical URL and looking it up in a local registry/repository." />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="Communication.inResponseTo" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Communication" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ref-1" />
+        <severity value="error" />
+        <human value="SHALL have a contained resource if a local reference is provided" />
+        <expression value="reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))" />
+        <xpath value="not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Communication" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+      </mapping>
+    </element>
+    <element id="Communication.status">
+      <path value="Communication.status" />
+      <short value="preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown" />
+      <definition value="The status of the transmission." />
+      <comment value="This element is labeled as a modifier because the status contains the codes aborted and entered-in-error that mark the communication as not currently valid." />
+      <min value="1" />
+      <max value="1" />
+      <base>
+        <path value="Communication.status" />
+        <min value="1" />
+        <max value="1" />
+      </base>
+      <type>
+        <code value="code" />
+      </type>
+      <fixedCode value="completed" />
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <isModifier value="true" />
+      <isModifierReason value="This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid" />
+      <isSummary value="true" />
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="CommunicationStatus" />
+        </extension>
+        <strength value="required" />
+        <description value="The status of the communication." />
+        <valueSet value="http://hl7.org/fhir/ValueSet/event-status|4.0.1" />
+      </binding>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.status" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.status" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-41" />
+        <comment value="status" />
+      </mapping>
+    </element>
+    <element id="Communication.statusReason">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.statusReason" />
+      <short value="Reason for current status" />
+      <definition value="Captures the reason for the current state of the Communication." />
+      <comment value="This is generally only used for &quot;exception&quot; statuses such as &quot;not-done&quot;, &quot;suspended&quot; or &quot;aborted&quot;. The reason for performing the event at all is captured in reasonCode, not here." />
+      <alias value="Suspended Reason" />
+      <alias value="Cancelled Reason" />
+      <min value="0" />
+      <max value="1" />
+      <base>
+        <path value="Communication.statusReason" />
+        <min value="0" />
+        <max value="1" />
+      </base>
+      <type>
+        <code value="CodeableConcept" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <isSummary value="true" />
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="CommunicationNotDoneReason" />
+        </extension>
+        <strength value="example" />
+        <description value="Codes for the reason why a communication did not happen." />
+        <valueSet value="http://hl7.org/fhir/ValueSet/communication-not-done-reason" />
+      </binding>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="v2" />
+        <map value="CE/CNE/CWE" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="CD" />
+      </mapping>
+      <mapping>
+        <identity value="orim" />
+        <map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.statusReason" />
+      </mapping>
+    </element>
+    <element id="Communication.category">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.category" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="$this" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <short value="Message category" />
+      <definition value="The type of message conveyed such as alert, notification, reminder, instruction, etc." />
+      <comment value="There may be multiple axes of categorization and one communication may serve multiple purposes." />
+      <min value="1" />
+      <max value="*" />
+      <base>
+        <path value="Communication.category" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="CodeableConcept" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="CommunicationCategory" />
+        </extension>
+        <strength value="example" />
+        <description value="Codes for general categories of communications such as alerts, instructions, etc." />
+        <valueSet value="http://hl7.org/fhir/ValueSet/communication-category" />
+      </binding>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="v2" />
+        <map value="CE/CNE/CWE" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="CD" />
+      </mapping>
+      <mapping>
+        <identity value="orim" />
+        <map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.class" />
+      </mapping>
+    </element>
+    <element id="Communication.category:patientCorrectionCommunicationType">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.category" />
+      <sliceName value="patientCorrectionCommunicationType" />
+      <short value="Message category" />
+      <definition value="The type of message conveyed such as alert, notification, reminder, instruction, etc." />
+      <comment value="There may be multiple axes of categorization and one communication may serve multiple purposes." />
+      <min value="1" />
+      <max value="1" />
+      <base>
+        <path value="Communication.category" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="CodeableConcept" />
+      </type>
+      <patternCodeableConcept>
+        <coding>
+          <system value="https://hl7.org/fhir/uv/fhir-patient-correction/CodeSystem/PatientCorrectionCommunicationTypes" />
+          <code value="medRecCxReq" />
+        </coding>
+      </patternCodeableConcept>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="CommunicationCategory" />
+        </extension>
+        <strength value="required" />
+        <description value="ValueSet of Communication types for patient request for corrections" />
+        <valueSet value="https://hl7.org/fhir/uv/fhir-patient-correction/ValueSet/PatientCorrectionCommunicationTypesVS" />
+      </binding>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="v2" />
+        <map value="CE/CNE/CWE" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="CD" />
+      </mapping>
+      <mapping>
+        <identity value="orim" />
+        <map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.class" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-49" />
+        <comment value="category" />
+      </mapping>
+    </element>
+    <element id="Communication.priority">
+      <path value="Communication.priority" />
+      <short value="routine | urgent | asap | stat" />
+      <definition value="Characterizes how quickly the planned or in progress communication must be addressed. Includes concepts such as stat, urgent, routine." />
+      <comment value="Used to prioritize workflow (such as which communication to read first) when the communication is planned or in progress." />
+      <min value="0" />
+      <max value="1" />
+      <base>
+        <path value="Communication.priority" />
+        <min value="0" />
+        <max value="1" />
+      </base>
+      <type>
+        <code value="code" />
+      </type>
+      <meaningWhenMissing value="If missing, this communication should be treated with normal priority" />
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <isSummary value="true" />
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="CommunicationPriority" />
+        </extension>
+        <strength value="required" />
+        <description value="Codes indicating the relative importance of a communication." />
+        <valueSet value="http://hl7.org/fhir/ValueSet/request-priority|4.0.1" />
+      </binding>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.grade" />
+      </mapping>
+    </element>
+    <element id="Communication.medium">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.medium" />
+      <short value="A channel of communication" />
+      <definition value="A channel that was used for this communication (e.g. email, fax)." />
+      <comment value="Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination." />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="Communication.medium" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="CodeableConcept" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="CommunicationMedium" />
+        </extension>
+        <strength value="example" />
+        <description value="Codes for communication mediums such as phone, fax, email, in person, etc." />
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationMode" />
+      </binding>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="v2" />
+        <map value="CE/CNE/CWE" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="CD" />
+      </mapping>
+      <mapping>
+        <identity value="orim" />
+        <map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+      </mapping>
+    </element>
+    <element id="Communication.subject">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.subject" />
+      <short value="The patient that the correction request applies to." />
+      <definition value="The patient or group that was the focus of this communication." />
+      <comment value="References SHALL be a reference to an actual FHIR resource, and SHALL be resolveable (allowing for access control, temporary unavailability, etc.). Resolution can be either by retrieval from the URL, or, where applicable by resource type, by treating an absolute reference as a canonical URL and looking it up in a local registry/repository." />
+      <alias value="patient" />
+      <min value="1" />
+      <max value="1" />
+      <base>
+        <path value="Communication.subject" />
+        <min value="0" />
+        <max value="1" />
+      </base>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ref-1" />
+        <severity value="error" />
+        <human value="SHALL have a contained resource if a local reference is provided" />
+        <expression value="reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))" />
+        <xpath value="not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Communication" />
+      </constraint>
+      <isSummary value="true" />
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.subject" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.subject[x]" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.subject" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-48" />
+        <comment value="subject" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-181" />
+        <comment value="Patient" />
+      </mapping>
+    </element>
+    <element id="Communication.topic">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.topic" />
+      <short value="A heading/subject line for the message being sent. Could be thought of as the subject line in an email thread." />
+      <definition value="Description of the purpose/content, similar to a subject line in an email." />
+      <comment value="Communication.topic.text can be used without any codings." />
+      <min value="1" />
+      <max value="1" />
+      <base>
+        <path value="Communication.topic" />
+        <min value="0" />
+        <max value="1" />
+      </base>
+      <type>
+        <code value="CodeableConcept" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <mustSupport value="false" />
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="CommunicationTopic" />
+        </extension>
+        <strength value="example" />
+        <description value="Codes describing the purpose or content of the communication." />
+        <valueSet value="http://hl7.org/fhir/ValueSet/communication-topic" />
+      </binding>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="v2" />
+        <map value="CE/CNE/CWE" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="CD" />
+      </mapping>
+      <mapping>
+        <identity value="orim" />
+        <map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.context" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-47" />
+        <comment value="topic" />
+      </mapping>
+    </element>
+    <element id="Communication.about">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.about" />
+      <short value="Resources that pertain to this communication" />
+      <definition value="Other resources that pertain to this communication and to which this communication should be associated." />
+      <comment value="Don't use Communication.about element when a more specific element exists, such as basedOn or reasonReference." />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="Communication.about" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Resource" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ref-1" />
+        <severity value="error" />
+        <human value="SHALL have a contained resource if a local reference is provided" />
+        <expression value="reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))" />
+        <xpath value="not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Communication" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.context" />
+      </mapping>
+    </element>
+    <element id="Communication.encounter">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.encounter" />
+      <short value="Encounter created as part of" />
+      <definition value="The Encounter during which this Communication was created or to which the creation of this record is tightly associated." />
+      <comment value="This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter." />
+      <min value="0" />
+      <max value="1" />
+      <base>
+        <path value="Communication.encounter" />
+        <min value="0" />
+        <max value="1" />
+      </base>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Encounter" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ref-1" />
+        <severity value="error" />
+        <human value="SHALL have a contained resource if a local reference is provided" />
+        <expression value="reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))" />
+        <xpath value="not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Communication" />
+      </constraint>
+      <isSummary value="true" />
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.context" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.context" />
+      </mapping>
+    </element>
+    <element id="Communication.sent">
+      <path value="Communication.sent" />
+      <short value="The date and time that this correction request was sent." />
+      <definition value="The time when this communication was sent." />
+      <min value="1" />
+      <max value="1" />
+      <base>
+        <path value="Communication.sent" />
+        <min value="0" />
+        <max value="1" />
+      </base>
+      <type>
+        <code value="dateTime" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.occurrence[x] {Invariant: maps to period.start}" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.done[x]" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-45" />
+        <comment value="sent" />
+      </mapping>
+    </element>
+    <element id="Communication.received">
+      <path value="Communication.received" />
+      <short value="When received" />
+      <definition value="The time when this communication arrived at the destination." />
+      <min value="0" />
+      <max value="1" />
+      <base>
+        <path value="Communication.received" />
+        <min value="0" />
+        <max value="1" />
+      </base>
+      <type>
+        <code value="dateTime" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.occurrence[x] {Invariant: maps to period.end}" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.done[x]" />
+      </mapping>
+    </element>
+    <element id="Communication.recipient">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.recipient" />
+      <slicing>
+        <discriminator>
+          <type value="profile" />
+          <path value="resolve()" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <short value="The recipient of the correction request, healthcare provider and optionally (if known) the health professional." />
+      <definition value="The entity (e.g. person, organization, clinical information system, care team or device) which was the target of the communication. If receipts need to be tracked by an individual, a separate resource instance will need to be created for each recipient.  Multiple recipient communications are intended where either receipts are not tracked (e.g. a mass mail-out) or a receipt is captured in aggregate (all emails confirmed received by a particular time)." />
+      <comment value="References SHALL be a reference to an actual FHIR resource, and SHALL be resolveable (allowing for access control, temporary unavailability, etc.). Resolution can be either by retrieval from the URL, or, where applicable by resource type, by treating an absolute reference as a canonical URL and looking it up in a local registry/repository." />
+      <min value="1" />
+      <max value="*" />
+      <base>
+        <path value="Communication.recipient" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ref-1" />
+        <severity value="error" />
+        <human value="SHALL have a contained resource if a local reference is provided" />
+        <expression value="reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))" />
+        <xpath value="not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Communication" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.performer.actor" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.actor" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-44" />
+        <comment value="recipient" />
+      </mapping>
+    </element>
+    <element id="Communication.recipient:healthcareProvider">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.recipient" />
+      <sliceName value="healthcareProvider" />
+      <short value="Message recipient" />
+      <definition value="The entity (e.g. person, organization, clinical information system, care team or device) which was the target of the communication. If receipts need to be tracked by an individual, a separate resource instance will need to be created for each recipient.  Multiple recipient communications are intended where either receipts are not tracked (e.g. a mass mail-out) or a receipt is captured in aggregate (all emails confirmed received by a particular time)." />
+      <comment value="References SHALL be a reference to an actual FHIR resource, and SHALL be resolveable (allowing for access control, temporary unavailability, etc.). Resolution can be either by retrieval from the URL, or, where applicable by resource type, by treating an absolute reference as a canonical URL and looking it up in a local registry/repository." />
+      <min value="1" />
+      <max value="1" />
+      <base>
+        <path value="Communication.recipient" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider-Organization" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ref-1" />
+        <severity value="error" />
+        <human value="SHALL have a contained resource if a local reference is provided" />
+        <expression value="reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))" />
+        <xpath value="not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Communication" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.performer.actor" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.actor" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-101" />
+        <comment value="Zorgaanbieder" />
+      </mapping>
+    </element>
+    <element id="Communication.recipient:healthProfessional">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.recipient" />
+      <sliceName value="healthProfessional" />
+      <short value="A reference from one resource to another" />
+      <definition value="A reference from one resource to another." />
+      <comment value="Each occurrence of the zib HealthProfessional is normally represented by _two_ FHIR resources: a PractitionerRole resource (instance of [nl-core-HealthProfessional-PractitionerRole](http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthProfessional-PractitionerRole)) and a Practitioner resource (instance of [nl-core-HealthProfessional-Practitioner](http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthProfessional-Practitioner)). The Practitioner resource is referenced from the PractitionerRole instance. For this reason, sending systems should fill the reference to the PractitionerRole instance here, and not the Practitioner resource. Receiving systems can then retrieve the reference to the Practitioner resource from that PractitionerRole instance.&#xD;&#xA;&#xD;&#xA;In rare circumstances, there is only a Practitioner instance, in which case it is that instance which will be referenced here. However, since this should be the exception, the zib-HealthProfessional-Practitioner profile is not explicitly mentioned as a target profile." />
+      <min value="0" />
+      <max value="1" />
+      <base>
+        <path value="Communication.recipient" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Reference" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/pattern-NlCoreHealthProfessionalReference" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthProfessional-PractitionerRole" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ref-1" />
+        <severity value="error" />
+        <human value="SHALL have a contained resource if a local reference is provided" />
+        <expression value="reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))" />
+        <xpath value="not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Communication" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.performer.actor" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.actor" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-182" />
+        <comment value="Zorgverlener" />
+      </mapping>
+    </element>
+    <element id="Communication.sender">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.sender" />
+      <short value="A reference to the sender of the correction request." />
+      <definition value="The entity (e.g. person, organization, clinical information system, or device) which was the source of the communication." />
+      <comment value="References SHALL be a reference to an actual FHIR resource, and SHALL be resolveable (allowing for access control, temporary unavailability, etc.). Resolution can be either by retrieval from the URL, or, where applicable by resource type, by treating an absolute reference as a canonical URL and looking it up in a local registry/repository." />
+      <min value="1" />
+      <max value="1" />
+      <base>
+        <path value="Communication.sender" />
+        <min value="0" />
+        <max value="1" />
+      </base>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ref-1" />
+        <severity value="error" />
+        <human value="SHALL have a contained resource if a local reference is provided" />
+        <expression value="reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))" />
+        <xpath value="not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Communication" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.performer.actor" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.actor" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-43" />
+        <comment value="sender" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-180" />
+        <comment value="Patient" />
+      </mapping>
+    </element>
+    <element id="Communication.reasonCode">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.reasonCode" />
+      <short value="Indication for message" />
+      <definition value="The reason or justification for the communication." />
+      <comment value="Textual reasons can be captured using reasonCode.text." />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="Communication.reasonCode" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="CodeableConcept" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <isSummary value="true" />
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="CommunicationReason" />
+        </extension>
+        <strength value="example" />
+        <description value="Codes for describing reasons for the occurrence of a communication." />
+        <valueSet value="http://hl7.org/fhir/ValueSet/clinical-findings" />
+      </binding>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="v2" />
+        <map value="CE/CNE/CWE" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="CD" />
+      </mapping>
+      <mapping>
+        <identity value="orim" />
+        <map value="fhir:CodeableConcept rdfs:subClassOf dt:CD" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.reasonCode" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.why[x]" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value=".reasonCode" />
+      </mapping>
+    </element>
+    <element id="Communication.reasonReference">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.reasonReference" />
+      <short value="Why was communication done?" />
+      <definition value="Indicates another resource whose existence justifies this communication." />
+      <comment value="References SHALL be a reference to an actual FHIR resource, and SHALL be resolveable (allowing for access control, temporary unavailability, etc.). Resolution can be either by retrieval from the URL, or, where applicable by resource type, by treating an absolute reference as a canonical URL and looking it up in a local registry/repository." />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="Communication.reasonReference" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Condition" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Observation" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/DiagnosticReport" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/DocumentReference" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ref-1" />
+        <severity value="error" />
+        <human value="SHALL have a contained resource if a local reference is provided" />
+        <expression value="reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))" />
+        <xpath value="not(starts-with(f:reference/@value, '#')) or exists(ancestor::*[self::f:entry or self::f:parameter]/f:resource/f:*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')]|/*/f:contained/f:*[f:id/@value=substring-after(current()/f:reference/@value, '#')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Communication" />
+      </constraint>
+      <isSummary value="true" />
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="The target of a resource reference is a RIM entry point (Act, Role, or Entity)" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.reasonReference" />
+      </mapping>
+      <mapping>
+        <identity value="w5" />
+        <map value="FiveWs.why[x]" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value=".outboundRelationship[typeCode=RSON].target" />
+      </mapping>
+    </element>
+    <element id="Communication.payload">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.payload" />
+      <short value="The actual correction request message as a string." />
+      <definition value="Text, attachment(s), or resource(s) that was communicated to the recipient." />
+      <min value="1" />
+      <max value="1" />
+      <base>
+        <path value="Communication.payload" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="BackboneElement" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-42" />
+        <comment value="payload" />
+      </mapping>
+    </element>
+    <element id="Communication.payload.id">
+      <path value="Communication.payload.id" />
+      <representation value="xmlAttr" />
+      <short value="Unique id for inter-element referencing" />
+      <definition value="Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces." />
+      <min value="0" />
+      <max value="1" />
+      <base>
+        <path value="Element.id" />
+        <min value="0" />
+        <max value="1" />
+      </base>
+      <type>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type">
+          <valueUrl value="string" />
+        </extension>
+        <code value="http://hl7.org/fhirpath/System.String" />
+      </type>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+    </element>
+    <element id="Communication.payload.extension">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.payload.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <description value="Extensions are always sliced by (at least) url" />
+        <rules value="open" />
+      </slicing>
+      <short value="Additional content defined by implementations" />
+      <definition value="May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." />
+      <comment value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+      <alias value="extensions" />
+      <alias value="user content" />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="Element.extension" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Extension" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ext-1" />
+        <severity value="error" />
+        <human value="Must have either extensions or value[x], not both" />
+        <expression value="extension.exists() != value.exists()" />
+        <xpath value="exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/DomainResource" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="N/A" />
+      </mapping>
+    </element>
+    <element id="Communication.payload.modifierExtension">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.payload.modifierExtension" />
+      <short value="Extensions that cannot be ignored even if unrecognized" />
+      <definition value="May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.&#xA;&#xA;Modifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself)." />
+      <comment value="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone." />
+      <requirements value="Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](extensibility.html#modifierExtension)." />
+      <alias value="extensions" />
+      <alias value="user content" />
+      <alias value="modifiers" />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="BackboneElement.modifierExtension" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Extension" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <constraint>
+        <key value="ext-1" />
+        <severity value="error" />
+        <human value="Must have either extensions or value[x], not both" />
+        <expression value="extension.exists() != value.exists()" />
+        <xpath value="exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])" />
+        <source value="http://hl7.org/fhir/StructureDefinition/DomainResource" />
+      </constraint>
+      <isModifier value="true" />
+      <isModifierReason value="Modifier extensions are expected to modify the meaning or interpretation of the element that contains them" />
+      <isSummary value="true" />
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="N/A" />
+      </mapping>
+    </element>
+    <element id="Communication.payload.content[x]">
+      <path value="Communication.payload.content[x]" />
+      <short value="Message part content" />
+      <definition value="A communicated content (or for multi-part communications, one portion of the communication)." />
+      <min value="1" />
+      <max value="1" />
+      <base>
+        <path value="Communication.payload.content[x]" />
+        <min value="1" />
+        <max value="1" />
+      </base>
+      <type>
+        <code value="string" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-199" />
+        <comment value="content" />
+      </mapping>
+    </element>
+    <element id="Communication.note">
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+        <valueCode value="normative" />
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version">
+        <valueCode value="4.0.0" />
+      </extension>
+      <path value="Communication.note" />
+      <short value="Comments made about the communication" />
+      <definition value="Additional notes or commentary about the communication by the sender, receiver or other interested parties." />
+      <comment value="For systems that do not have structured annotations, they can simply communicate a single annotation with no author or time.  This element may need to be included in narrative because of the potential for modifying information.  *Annotations SHOULD NOT* be used to communicate &quot;modifying&quot; information that could be computable. (This is a SHOULD because enforcing user behavior is nearly impossible)." />
+      <min value="0" />
+      <max value="*" />
+      <base>
+        <path value="Communication.note" />
+        <min value="0" />
+        <max value="*" />
+      </base>
+      <type>
+        <code value="Annotation" />
+      </type>
+      <condition value="ele-1" />
+      <constraint>
+        <key value="ele-1" />
+        <severity value="error" />
+        <human value="All FHIR elements must have a @value or children" />
+        <expression value="hasValue() or (children().count() &gt; id.count())" />
+        <xpath value="@value|f:*|h:div" />
+        <source value="http://hl7.org/fhir/StructureDefinition/Element" />
+      </constraint>
+      <mapping>
+        <identity value="rim" />
+        <map value="n/a" />
+      </mapping>
+      <mapping>
+        <identity value="v2" />
+        <map value="N/A" />
+      </mapping>
+      <mapping>
+        <identity value="rim" />
+        <map value="Act" />
+      </mapping>
+      <mapping>
+        <identity value="workflow" />
+        <map value="Event.note" />
+      </mapping>
+    </element>
+  </snapshot>
+  <differential>
+    <element id="Communication.identifier">
+      <path value="Communication.identifier" />
+      <min value="1" />
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-40" />
+        <comment value="identifier" />
+      </mapping>
+    </element>
+    <element id="Communication.status">
+      <path value="Communication.status" />
+      <fixedCode value="completed" />
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-41" />
+        <comment value="status" />
+      </mapping>
+    </element>
+    <element id="Communication.category">
+      <path value="Communication.category" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="$this" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <min value="1" />
+    </element>
+    <element id="Communication.category:patientCorrectionCommunicationType">
+      <path value="Communication.category" />
+      <sliceName value="patientCorrectionCommunicationType" />
+      <min value="1" />
+      <max value="1" />
+      <patternCodeableConcept>
+        <coding>
+          <system value="https://hl7.org/fhir/uv/fhir-patient-correction/CodeSystem/PatientCorrectionCommunicationTypes" />
+          <code value="medRecCxReq" />
+        </coding>
+      </patternCodeableConcept>
+      <binding>
+        <strength value="required" />
+        <description value="ValueSet of Communication types for patient request for corrections" />
+        <valueSet value="https://hl7.org/fhir/uv/fhir-patient-correction/ValueSet/PatientCorrectionCommunicationTypesVS" />
+      </binding>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-49" />
+        <comment value="category" />
+      </mapping>
+    </element>
+    <element id="Communication.subject">
+      <path value="Communication.subject" />
+      <short value="The patient that the correction request applies to." />
+      <min value="1" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient" />
+      </type>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-48" />
+        <comment value="subject" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-181" />
+        <comment value="Patient" />
+      </mapping>
+    </element>
+    <element id="Communication.topic">
+      <path value="Communication.topic" />
+      <short value="A heading/subject line for the message being sent. Could be thought of as the subject line in an email thread." />
+      <min value="1" />
+      <mustSupport value="false" />
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-47" />
+        <comment value="topic" />
+      </mapping>
+    </element>
+    <element id="Communication.sent">
+      <path value="Communication.sent" />
+      <short value="The date and time that this correction request was sent." />
+      <min value="1" />
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-45" />
+        <comment value="sent" />
+      </mapping>
+    </element>
+    <element id="Communication.recipient">
+      <path value="Communication.recipient" />
+      <slicing>
+        <discriminator>
+          <type value="profile" />
+          <path value="resolve()" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <short value="The recipient of the correction request, healthcare provider and optionally (if known) the health professional." />
+      <min value="1" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole" />
+      </type>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-44" />
+        <comment value="recipient" />
+      </mapping>
+    </element>
+    <element id="Communication.recipient:healthcareProvider">
+      <path value="Communication.recipient" />
+      <sliceName value="healthcareProvider" />
+      <min value="1" />
+      <max value="1" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider-Organization" />
+      </type>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-101" />
+        <comment value="Zorgaanbieder" />
+      </mapping>
+    </element>
+    <element id="Communication.recipient:healthProfessional">
+      <path value="Communication.recipient" />
+      <sliceName value="healthProfessional" />
+      <max value="1" />
+      <type>
+        <code value="Reference" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/pattern-NlCoreHealthProfessionalReference" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthProfessional-PractitionerRole" />
+      </type>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-182" />
+        <comment value="Zorgverlener" />
+      </mapping>
+    </element>
+    <element id="Communication.sender">
+      <path value="Communication.sender" />
+      <short value="A reference to the sender of the correction request." />
+      <min value="1" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient" />
+      </type>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-43" />
+        <comment value="sender" />
+      </mapping>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-180" />
+        <comment value="Patient" />
+      </mapping>
+    </element>
+    <element id="Communication.payload">
+      <path value="Communication.payload" />
+      <short value="The actual correction request message as a string." />
+      <min value="1" />
+      <max value="1" />
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-42" />
+        <comment value="payload" />
+      </mapping>
+    </element>
+    <element id="Communication.payload.content[x]">
+      <path value="Communication.payload.content[x]" />
+      <type>
+        <code value="string" />
+      </type>
+      <mapping>
+        <identity value="art-decor-dossierwijzigingsverzoek" />
+        <map value="dwv-dataelement-199" />
+        <comment value="content" />
+      </mapping>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/contentValidation/test/out/dwv-Transaction-Scenario-1.xml
+++ b/contentValidation/test/out/dwv-Transaction-Scenario-1.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+   <id value="dwv-Transaction-Scenario-1"/>
+   <url value="http://nictiz.nl/fhir/StructureDefinition/Test/dwv-Transaction-Scenario-1"/>
+   <name value="dwvTransactionScenario1"/>
+   <title value="dwv Transaction Scenario 1"/>
+   <status value="draft"/>
+   <experimental value="true"/>
+   <description value="Constrained profile for qualification purposes. Not suited for implementation."/>
+   <fhirVersion value="4.0.1"/>
+   <kind value="resource"/>
+   <abstract value="false"/>
+   <type value="Bundle"/>
+   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Bundle"/>
+   <derivation value="constraint"/>
+   <differential>
+      <element id="Bundle.type">
+         <path value="Bundle.type"/>
+         <fixedCode value="transaction"/>
+      </element>
+      <element id="Bundle.entry">
+         <path value="Bundle.entry"/>
+         <slicing>
+            <discriminator>
+               <type value="profile"/>
+               <path value="resource"/>
+            </discriminator>
+            <rules value="open"/>
+         </slicing>
+      </element>
+      <element id="Bundle.entry:communication">
+         <path value="Bundle.entry"/>
+         <sliceName value="communication"/>
+         <min value="1"/>
+         <max value="1"/>
+      </element>
+      <element id="Bundle.entry:communication.resource">
+         <path value="Bundle.entry.resource"/>
+         <min value="1"/>
+         <type>
+            <code value="Resource"/>
+            <profile value="http://nictiz.nl/fhir/StructureDefinition/dwv-PatientCorrectionsCommunication"/>
+         </type>
+      </element>
+      <element id="Bundle.entry:communication.resource.identifier.system">
+         <path value="Bundle.entry.resource.identifier.system"/>
+         <min value="1"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.identifier.value">
+         <path value="Bundle.entry.resource.identifier.value"/>
+         <min value="1"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.category.coding">
+         <path value="Bundle.entry.resource.category.coding"/>
+         <slicing>
+            <discriminator>
+               <type value="value"/>
+               <path value="code"/>
+            </discriminator>
+            <discriminator>
+               <type value="value"/>
+               <path value="system"/>
+            </discriminator>
+            <rules value="open"/>
+         </slicing>
+         <min value="1"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.category.coding:requiredCoding">
+         <path value="Bundle.entry.resource.category.coding"/>
+         <sliceName value="requiredCoding"/>
+         <min value="1"/>
+         <max value="1"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.category.coding:requiredCoding.system">
+         <path value="Bundle.entry.resource.category.coding.system"/>
+         <min value="1"/>
+         <fixedUri value="https://hl7.org/fhir/uv/fhir-patient-correction/CodeSystem/PatientCorrectionCommunicationTypes"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.category.coding:requiredCoding.code">
+         <path value="Bundle.entry.resource.category.coding.code"/>
+         <min value="1"/>
+         <fixedCode value="medRecCxReq"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.category.coding:requiredCoding.display">
+         <path value="Bundle.entry.resource.category.coding.display"/>
+         <min value="1"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.subject">
+         <path value="Bundle.entry.resource.subject"/>
+         <type>
+            <code value="Reference"/>
+            <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient"/>
+         </type>
+      </element>
+      <element id="Bundle.entry:communication.resource.subject.reference">
+         <path value="Bundle.entry.resource.subject.reference"/>
+         <min value="1"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.subject.type">
+         <path value="Bundle.entry.resource.subject.type"/>
+         <min value="1"/>
+         <fixedUri value="Patient"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.subject.display">
+         <path value="Bundle.entry.resource.subject.display"/>
+         <min value="1"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.topic.text">
+         <path value="Bundle.entry.resource.topic.text"/>
+         <fixedString value="Telefoonnummer wijzigen"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.recipient:healthcareProvider">
+         <path value="Bundle.entry.resource.recipient"/>
+         <sliceName value="healthcareProvider"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.recipient:healthcareProvider.reference">
+         <path value="Bundle.entry.resource.recipient.reference"/>
+         <min value="1"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.recipient:healthcareProvider.type">
+         <path value="Bundle.entry.resource.recipient.type"/>
+         <min value="1"/>
+         <fixedUri value="Organization"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.recipient:healthcareProvider.display">
+         <path value="Bundle.entry.resource.recipient.display"/>
+         <min value="1"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.sender">
+         <path value="Bundle.entry.resource.sender"/>
+         <type>
+            <code value="Reference"/>
+            <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient"/>
+         </type>
+      </element>
+      <element id="Bundle.entry:communication.resource.sender.reference">
+         <path value="Bundle.entry.resource.sender.reference"/>
+         <min value="1"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.sender.type">
+         <path value="Bundle.entry.resource.sender.type"/>
+         <min value="1"/>
+         <fixedUri value="Patient"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.sender.display">
+         <path value="Bundle.entry.resource.sender.display"/>
+         <min value="1"/>
+      </element>
+      <element id="Bundle.entry:communication.resource.payload.content[x]">
+         <path value="Bundle.entry.resource.payload.content[x]"/>
+         <min value="1"/>
+         <fixedString value="Ik heb in mijn dossier gezien dat mijn telefoonnummer niet klopt. Dit wil ik graag gewijzigd hebben. Mijn telefoonnummer is 06-12345678."/>
+      </element>
+   </differential>
+</StructureDefinition>

--- a/contentValidation/xslt/generateProfile.xsl
+++ b/contentValidation/xslt/generateProfile.xsl
@@ -1,0 +1,578 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    xmlns:f="http://hl7.org/fhir"
+    xmlns:nts="http://nictiz.nl/xsl/testscript"
+    xmlns:nf="http://www.nictiz.nl/functions"
+    xmlns:TODO="TODO"
+    xmlns="http://hl7.org/fhir"
+    exclude-result-prefixes="#all"
+    version="2.0">
+    
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+    
+    <xsl:param name="debug" select="true()"/>
+    
+    <xsl:param name="fhirPackage" select="'nictiz.fhir.nl.r4.patientcorrections'"/>
+    <xsl:param name="fhirPackageVersion" select="'1.0.0'"/>
+    
+    <xsl:template match="/">
+        <xsl:variable name="fileName" select="substring-before(tokenize(base-uri(),'/')[last()], '.xml')"/>
+        <xsl:variable name="resourceType" select="local-name(*)"/>
+        
+        <StructureDefinition xmlns="http://hl7.org/fhir">
+            <id value="{$fileName}"/>
+            <url value="http://nictiz.nl/fhir/StructureDefinition/Test/{$fileName}"/>
+            <name value="{replace($fileName, '-', '')}"/>
+            <title value="{replace($fileName, '-', ' ')}"/>
+            <status value="draft"/>
+            <experimental value="true"/>
+            <description value="Constrained profile for qualification purposes. Not suited for implementation."/>
+            <fhirVersion value="4.0.1"/>
+            <kind value="resource"/>
+            <abstract value="false"/>
+            <type value="{$resourceType}"/>
+            <baseDefinition value="http://hl7.org/fhir/StructureDefinition/{$resourceType}"/>
+            <derivation value="constraint"/>
+            <differential>
+                <!-- Currently works on a Bundle fixture and only processes the first entry. If there are multiple entries to be checked, can we combine them in 1 profile?
+                And: this should be made to function to create a profile on 1 separate resource, that is expected to be returned in a searchset Bundle -->
+                <xsl:apply-templates select="*/*">
+                    <xsl:with-param name="elementId" select="$resourceType"/>
+                    <xsl:with-param name="path" select="$resourceType"/>
+                </xsl:apply-templates>
+            </differential>
+        </StructureDefinition>
+    </xsl:template>
+    
+    <xsl:template match="f:Bundle/f:type">
+        <xsl:param name="elementId"/>
+        <element id="{nf:constructIdOrPath(., $elementId)}">
+            <path value="Bundle.type"/>
+            <fixedCode value="{@value}"/>
+        </element>
+    </xsl:template>
+    
+    <xsl:template match="f:Bundle/f:entry">
+        <xsl:param name="elementId"/>
+        <xsl:param name="path"/>
+        
+        <xsl:variable name="sliceName" select="lower-case(f:resource/f:*/local-name())"/>
+        
+        <!-- Process all entries? Or the ones selected by some nts:generateProfile attribute? -->
+        <xsl:if test="not(preceding-sibling::f:entry)">
+            <element id="{nf:constructIdOrPath(., $elementId)}">
+                <path value="{nf:constructIdOrPath(., $path)}"/>
+                <slicing>
+                    <discriminator>
+                        <type value="profile"/>
+                        <path value="resource"/>
+                    </discriminator>
+                    <rules value="open"/>
+                </slicing>
+            </element>
+            <element id="{nf:constructIdOrPath(., $elementId)}:{$sliceName}">
+                <path value="Bundle.entry"/>
+                <sliceName value="{$sliceName}"/>
+                <min value="1"/>
+                <max value="1"/>
+            </element>
+            
+            <xsl:apply-templates select="*">
+                <xsl:with-param name="elementId" select="concat(nf:constructIdOrPath(., $elementId),':',$sliceName)"/>
+                <xsl:with-param name="path" select="nf:constructIdOrPath(., $path)"/>
+            </xsl:apply-templates>
+        </xsl:if>
+    </xsl:template>
+    
+    <!-- We can move the common assert here. For know: do nothing. -->
+    <xsl:template match="f:Bundle/f:entry/f:fullUrl"/>
+    <!-- Lets think of some checks to do matching Bundle type to this, but silencing it for now -->
+    <xsl:template match="f:Bundle/f:entry/f:request"/>
+    
+    <xsl:template match="f:Bundle/f:entry/f:resource">
+        <xsl:param name="elementId"/>
+        <xsl:param name="path"/>
+        
+        <xsl:variable name="elementIdNew" select="nf:constructIdOrPath(., $elementId)"/>
+        <xsl:variable name="pathNew" select="nf:constructIdOrPath(., $path)"/>
+        <xsl:variable name="profile" select="f:*/f:meta/f:profile[1]/@value"/>
+        <xsl:variable name="structureDefinition">
+            <xsl:call-template name="getStructureDefinition">
+                <xsl:with-param name="profile" select="$profile"/>
+            </xsl:call-template>
+        </xsl:variable>
+        
+        <element id="{$elementIdNew}">
+            <path value="{$pathNew}"/>
+            <min value="1"/>
+            <type>
+                <code value="Resource"/>
+                <profile value="{$profile}"/>
+            </type>
+        </element>
+        
+        <!-- Skit the resourcetype element, we do not have anything to do there when starting from a Bundle -->
+        <xsl:apply-templates select="f:*/f:*">
+            <xsl:with-param name="elementId" select="$elementIdNew"/>
+            <xsl:with-param name="path" select="$pathNew"/>
+            <!-- This is a shortcut, we assume the child of f:resource is always an element with the same name as its resourceType. Type will stay the same up to the point that we want to dive into BackboneElements, extensions and/or datatype profiles -->
+            <xsl:with-param name="type" select="f:*/local-name()" tunnel="yes"/>
+            <xsl:with-param name="structureDefinition" select="$structureDefinition" tunnel="yes"/>
+        </xsl:apply-templates>
+    </xsl:template>
+    
+    <!-- Here we start the real work -->
+    <xsl:template match="f:Bundle/f:entry/f:resource/f:*//f:*">
+        <xsl:param name="elementId"/>
+        <xsl:param name="path"/>
+        <xsl:param name="type" tunnel="yes"/>
+        
+        <xsl:variable name="pathNew" select="nf:constructIdOrPath(., $path)"/>
+        
+        <!-- We get the corresponding elementDefinition here, because it is used multiple times in templates after this one. -->
+        <xsl:variable name="elementDefinition">
+            <xsl:call-template name="getElementDefinitions">
+                <xsl:with-param name="path" select="$pathNew"/>
+                <xsl:with-param name="parentPath" select="$path"/>
+                <xsl:with-param name="parentType" select="$type"/>
+            </xsl:call-template>
+        </xsl:variable>
+        
+        <xsl:variable name="elementType">
+            <xsl:call-template name="getElementType">
+                <xsl:with-param name="elementDefinition" select="$elementDefinition"/>
+            </xsl:call-template>
+        </xsl:variable>
+        <xsl:variable name="isSliced" as="xs:boolean">
+            <xsl:call-template name="checkSlicing">
+                <xsl:with-param name="elementDefinition" select="$elementDefinition"/>
+            </xsl:call-template>
+        </xsl:variable>
+        
+        <!-- The element id takes significant effort, while its only use should be for identification. Would it be possible to fill it with some other random value? Then we can concentrate on the path, which is actually used. Looking at the definition: https://www.hl7.org/fhir/R4/element-definitions.html#Element.id this seems to be true, but actually I doubt if this will work. Constraints on sliced subelements only work because their .id refers to which slice the constraint belongs to. -->
+        <xsl:variable name="elementIdNew" select="nf:constructIdOrPath(., $elementId)"/>
+        
+        <!-- Determine which action to take based on elementType -->
+        <xsl:choose>
+            <xsl:when test="$elementType = 'code'">
+                <!-- Just check for fixed value I guess. Not present in the example output, because the profile actually fixed the value. I guess duplicating this does not matter, but that should be checked. -->
+            </xsl:when>
+            
+            <xsl:when test="$elementType = 'CodeableConcept'">
+                <xsl:choose>
+                    <xsl:when test="f:coding">
+                        <!-- Slice on coding, to allow other codings then the ones we 'prescribe' to be present
+                        What happens when there is already slicing present? I guess we can check for that using structureDefinition ... See 'Reference' for a way to do that. -->
+                        <element id="{$elementIdNew}.coding">
+                            <path value="{$pathNew}.coding"/>
+                            <slicing>
+                                <discriminator>
+                                    <type value="value"/>
+                                    <path value="code"/>
+                                </discriminator>
+                                <discriminator>
+                                    <type value="value"/>
+                                    <path value="system"/>
+                                </discriminator>
+                                <rules value="open"/>
+                            </slicing>
+                            <min value="{count(f:coding)}"/>
+                        </element>
+                        <xsl:for-each select="f:coding">
+                            <!-- Instead of 'requiredCoding', make it something more meaningful like 'requiredCategoryCoding'? -->
+                            <xsl:variable name="sliceName" select="string-join(('requiredCoding',if (count(preceding-sibling::f:coding) ne 0) then count(preceding-sibling::f:coding) + 1 else ''),'')"/>
+                            <xsl:variable name="elementIdFull" select="concat($elementIdNew, '.coding:', $sliceName)"/>
+                            <xsl:variable name="pathFull" select="concat($pathNew, '.coding')"/>
+                            
+                            <element id="{$elementIdFull}">
+                                <path value="{$pathFull}"/>
+                                <sliceName value="{$sliceName}"/>
+                                <min value="1"/>
+                                <max value="1"/>
+                            </element>
+                            <element id="{$elementIdFull}.system">
+                                <path value="{$pathFull}.system"/>
+                                <min value="1"/>
+                                <fixedUri value="{f:system/@value}"/>
+                            </element>
+                            <element id="{$elementIdFull}.code">
+                                <path value="{$pathFull}.code"/>
+                                <min value="1"/>
+                                <fixedCode value="{f:code/@value}"/>
+                            </element>
+                            <!-- Also check for display contents? Maybe by constraint (regex). But doesn't the validator do this already? -->
+                            <element id="{$elementIdFull}.display">
+                                <path value="{$pathFull}.display"/>
+                                <min value="1"/>
+                            </element>
+                        </xsl:for-each>
+                        <!-- f:text? -->
+                    </xsl:when>
+                    <xsl:when test="f:text">
+                        <element id="{$elementIdNew}.text">
+                            <path value="{$pathNew}.text"/>
+                            <fixedString value="{f:text/@value}"/>
+                        </element>
+                    </xsl:when>
+                </xsl:choose>
+            </xsl:when>
+            
+            <xsl:when test="$elementType = 'dateTime'">
+                <!-- Do some T-date magic here? Check for Time pattern with constraint/regex? How to handle time zones? -->
+            </xsl:when>
+            
+            <xsl:when test="$elementType = 'Identifier'">
+                <element id="{$elementIdNew}.system">
+                    <path value="{$pathNew}.system"/>
+                    <min value="1"/>
+                </element>
+                <element id="{$elementIdNew}.value">
+                    <path value="{$pathNew}.value"/>
+                    <min value="1"/>
+                </element>
+                <!-- We could also check the contents of .system and .value more, like we do with a common assert at the moment. -->
+            </xsl:when>
+            
+            <xsl:when test="$elementType = 'Meta'">
+                <!-- Check meta.profile? This is done by common assert at the moment. -->
+            </xsl:when>
+            
+            <xsl:when test="$elementType = 'Reference'">
+                <xsl:variable name="targetProfile">
+                    <!-- How can we determine correct targetProfile? Some 'resolveReference' function that searches for the file and checks that for Meta.profile? Up to that point: try to get away by using .type -->
+                    <xsl:variable name="type" select="f:type/@value"/>
+                    <xsl:text>http://nictiz.nl/fhir/StructureDefinition/nl-core-</xsl:text>
+                    <xsl:choose>
+                        <xsl:when test="$type = 'Patient'">Patient</xsl:when>
+                        <xsl:when test="$type = 'Organization'">HealthcareProvider-Organization</xsl:when>
+                        <xsl:otherwise>
+                            <xsl:message terminate="yes">Need a Reference targetProfile for <xsl:value-of select="$type"/></xsl:message>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+                <xsl:variable name="sliceName">
+                    <xsl:if test="$isSliced">
+                        <xsl:value-of select="$elementDefinition/f:element[f:type/f:targetProfile/@value = $targetProfile]/f:sliceName/@value"/>
+                    </xsl:if>
+                </xsl:variable>
+                <xsl:variable name="constrainTargetProfile" as="xs:boolean">
+                    <xsl:choose>
+                        <xsl:when test="$isSliced and count($elementDefinition/f:element[f:sliceName/@value = $sliceName]/f:type/f:targetProfile) gt 1">
+                            <xsl:value-of select="true()"/>
+                        </xsl:when>
+                        <xsl:when test="not($isSliced) and count($elementDefinition/f:element/f:type/f:targetProfile) gt 1">
+                            <xsl:value-of select="true()"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="false()"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+                <xsl:variable name="elementIdFull" select="if (string-length($sliceName) gt 0) then concat($elementIdNew,':',$sliceName) else $elementIdNew "/>
+                
+                <!-- If the elementDefinition contains multiple targetProfiles, we can constrain the element further by only allowing 1 targetProfile. If the elementDefinition only contains 1 targetProfile, there is no need. 
+                Also, if the element is sliced, we need to add this element -->
+                <xsl:if test="$constrainTargetProfile or $isSliced">
+                    <element id="{$elementIdFull}">
+                        <path value="{$pathNew}"/>
+                        <xsl:if test="$isSliced">
+                            <sliceName value="{$sliceName}"/>
+                        </xsl:if>
+                        <xsl:if test="$constrainTargetProfile">
+                            <type>
+                                <code value="Reference"/>
+                                <targetProfile value="{$targetProfile}"/>
+                            </type>
+                        </xsl:if>
+                    </element>
+                </xsl:if>
+                
+                <element id="{$elementIdFull}.reference">
+                    <path value="{$pathNew}.reference"/>
+                    <min value="1"/>
+                </element>
+                <element id="{$elementIdFull}.type">
+                    <path value="{$pathNew}.type"/>
+                    <min value="1"/>
+                    <fixedUri value="{f:type/@value}"/>
+                </element>
+                <element id="{$elementIdFull}.display">
+                    <path value="{$pathNew}.display"/>
+                    <min value="1"/>
+                </element>
+            </xsl:when>
+            
+            <xsl:when test="$elementType = 'string'">
+                <element id="{$elementIdNew}">
+                    <path value="{$pathNew}"/>
+                    <min value="1"/>
+                    <fixedString value="{@value}"/>
+                </element>
+            </xsl:when>
+            
+            <xsl:when test="$elementType = 'BackboneElement'">
+                <!-- Go one step deeper -->
+                <xsl:apply-templates select="f:*">
+                    <xsl:with-param name="elementId" select="$elementIdNew"/>
+                    <xsl:with-param name="path" select="$pathNew"/>
+                    <!-- If we have to do this, is 'type' really the best variable name? -->
+                    <xsl:with-param name="type" select="concat($type, '.', local-name())" tunnel="yes"/>
+                </xsl:apply-templates>
+            </xsl:when>
+            
+            <xsl:otherwise>
+                <xsl:message terminate="yes">Unknown elementType: <xsl:value-of select="$elementType"/></xsl:message>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- Construct element id or path by combining the 'inherited' id/path and the local element. Main goal is to detect and process choice (polymorphic) elements.
+    Element id differs from path in that it also contains slicenames. These are added to the 'inherited' input param if applicable-->
+    <xsl:function name="nf:constructIdOrPath">
+        <xsl:param name="in"/>
+        <xsl:param name="inherited"/>
+        
+        <xsl:variable name="local">
+            <xsl:if test="$inherited">
+                <xsl:text>.</xsl:text>
+            </xsl:if>
+            <xsl:choose>
+                <xsl:when test="nf:isChoiceElement($in/local-name())">
+                    <xsl:value-of select="nf:createChoiceElement($in/local-name())"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="$in/local-name()"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+        <xsl:value-of select="concat($inherited, $local)"/>
+    </xsl:function>
+    
+    <!-- Returns true or false if a choice element is deteced. Contains some hard coded overrides ('postalCode'), maybe there are more. -->
+    <xsl:function name="nf:isChoiceElement" as="xs:boolean">
+        <xsl:param name="path" as="xs:string"/>
+        <xsl:variable name="datatypes" select="('Address','Annotation','Attachment','Boolean','CodeableConcept','Coding','Code','ContactPoint','Count','Date','DateTime','Decimal','Dosage','HumanName','Identifier','Integer','Period','SimpleQuantity','Quantity','Age','Distance','Duration','Money','Ratio','Reference','SampledData','String','Time','Timing','Uri')"/>
+        
+        <xsl:choose>
+            <xsl:when test="ends-with($path,'postalCode')">
+                <xsl:value-of select="false()"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="some $datatype in $datatypes satisfies ends-with($path, $datatype)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+    
+    <!-- When given a string, returns the portion of the string before a FHIR datatype and adds '[x]'. -->
+    <xsl:function name="nf:createChoiceElement" as="xs:string">
+        <xsl:param name="path" as="xs:string"/>
+        <xsl:variable name="valuePath">
+            <xsl:choose>
+                <xsl:when test="ends-with($path,'Address')">
+                    <xsl:value-of select="substring-before($path,'Address')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Annotation')">
+                    <xsl:value-of select="substring-before($path,'Annotation')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Attachment')">
+                    <xsl:value-of select="substring-before($path,'Attachment')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Boolean')">
+                    <xsl:value-of select="substring-before($path,'Boolean')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'CodeableConcept')">
+                    <xsl:value-of select="substring-before($path,'CodeableConcept')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Coding')">
+                    <xsl:value-of select="substring-before($path,'Coding')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Code')">
+                    <xsl:value-of select="substring-before($path,'Code')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'ContactPoint')">
+                    <xsl:value-of select="substring-before($path,'ContactPoint')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Count')">
+                    <xsl:value-of select="substring-before($path,'Count')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Date')">
+                    <xsl:value-of select="substring-before($path,'Date')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'DateTime')">
+                    <xsl:value-of select="substring-before($path,'DateTime')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Decimal')">
+                    <xsl:value-of select="substring-before($path,'Decimal')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Dosage')">
+                    <xsl:value-of select="substring-before($path,'Dosage')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'HumanName')">
+                    <xsl:value-of select="substring-before($path,'HumanName')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Identifier')">
+                    <xsl:value-of select="substring-before($path,'Identifier')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Integer')">
+                    <xsl:value-of select="substring-before($path,'Integer')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Period')">
+                    <xsl:value-of select="substring-before($path,'Period')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Quantity')">
+                    <xsl:value-of select="substring-before($path,'Quantity')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Age')">
+                    <xsl:value-of select="substring-before($path,'Age')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Distance')">
+                    <xsl:value-of select="substring-before($path,'Distance')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Duration')">
+                    <xsl:value-of select="substring-before($path,'Duration')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Money')">
+                    <xsl:value-of select="substring-before($path,'Money')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'SimpleQuantity')">
+                    <xsl:value-of select="substring-before($path,'SimpleQuantity')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Ratio')">
+                    <xsl:value-of select="substring-before($path,'Ratio')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Reference')">
+                    <xsl:value-of select="substring-before($path,'Reference')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'SampledData')">
+                    <xsl:value-of select="substring-before($path,'SampledData')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'String')">
+                    <xsl:value-of select="substring-before($path,'String')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Time')">
+                    <xsl:value-of select="substring-before($path,'Time')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Timing')">
+                    <xsl:value-of select="substring-before($path,'Timing')"/>
+                </xsl:when>
+                <xsl:when test="ends-with($path,'Uri')">
+                    <xsl:value-of select="substring-before($path,'Uri')"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="$path"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:value-of select="concat($valuePath,'[x]')"/>
+    </xsl:function>
+    
+    <!-- Resolves a canonical in scope of a package at Simplifier, loads the resulting page as unparsed text and then regexes the page to search for the 'download snapshot' link. If anything changes at Simplifier, we should look at this one.-->
+    <xsl:template name="getStructureDefinition">
+        <xsl:param name="profile" select="f:meta/f:profile/@value"/>
+        
+        <xsl:variable name="packageFileId">
+            <xsl:analyze-string select="unparsed-text(concat('https://simplifier.net/resolve?scope=',$fhirPackage,'@',$fhirPackageVersion,'&amp;canonical=',$profile))" regex="[/]ui[/]packagefile[/]downloadsnapshotas[?]packageFileId=([0-9]{{5,6}})[&amp;]amp;format=xml">
+                <xsl:matching-substring>
+                    <xsl:copy-of select="regex-group(1)"/>
+                </xsl:matching-substring>
+            </xsl:analyze-string>
+        </xsl:variable>
+        
+        <xsl:if test="$debug">
+            <xsl:message>profile: <xsl:value-of select="$profile"/> - packageFileId: '<xsl:value-of select="$packageFileId"/>'</xsl:message>
+        </xsl:if>
+        
+        <xsl:choose>
+            <xsl:when test="string-length($packageFileId) gt 0">
+                <xsl:variable name="structureDefinition" select="document(concat('https://simplifier.net/ui/packagefile/downloadsnapshotas?packageFileId=',$packageFileId,'&amp;format=xml'))"/>
+                <xsl:copy-of select="$structureDefinition"/>
+                
+                <!-- Add StructureDefinitions of referenced datatype and extension profiles. For example: when no differential is present when dealing with a type profile, no SD-info is available in the snapshot (nl-core-patient, Patient.address for example). So we should add these to the set of SDs -->
+                <xsl:for-each select="distinct-values($structureDefinition//f:element/f:type/f:profile/@value)">
+                    <xsl:call-template name="getStructureDefinition">
+                        <xsl:with-param name="profile" select="."/>
+                    </xsl:call-template>
+                </xsl:for-each>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:message terminate="yes">Unable to download snapshot for profile '<xsl:value-of select="$profile"/>'</xsl:message>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- For a given element.path, get it's element type. -->
+    <xsl:template name="getElementType">
+        <xsl:param name="elementDefinition" required="yes"/>
+        
+        <!-- The type seems to be the same in all elementDefinitions present, so we pick the first one. Have yet to encounter situations where this isn't the case -->
+        <xsl:variable name="elementType" select="($elementDefinition/f:element)[1]/f:type/f:code/@value"/>
+
+        <xsl:if test="$debug">
+            <xsl:message select="concat('elementType: ',$elementType)"/>
+        </xsl:if>
+        <xsl:value-of select="$elementType"/>
+        
+    </xsl:template>
+    
+    <!-- For a given element.path, check if the element is sliced in the profile this resources is based on. If not, we can create our own slice for the checks we want to do. Otherwise, we have to use the existing slice and its properties -->
+    <xsl:template name="checkSlicing">
+        <xsl:param name="elementDefinition" required="yes"/>
+        
+        <xsl:choose>
+            <xsl:when test="$elementDefinition/f:element/f:slicing">
+                <xsl:value-of select="true()"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="false()"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- For a given element.path, search the given set of StructureDefintions for a match and returns ElementDefinition for that match.
+    If no match is found, part of the path is replaced by parentType to search again. Example: no match will probably be found for 'Bundle.entry.resource.identifier', if we replace 'Bundle.entry.resource' with the resourceType, it will probably result in a match.
+    
+    This can result in multiple ElementDefinitions being found because of slicing. Logic to determine which one is needed should be in place later. 
+    -->
+    <xsl:template name="getElementDefinitions" as="element(f:element)*">
+        <xsl:param name="structureDefinition" tunnel="yes" required="yes"/>
+        <xsl:param name="path" required="yes"/>
+        <xsl:param name="parentPath"/>
+        <xsl:param name="parentType"/>
+        
+        <xsl:if test="$debug">
+            <xsl:message select="concat('getElementDefinitions: path = ',$path, ' - parentPath = ', $parentPath, ' - parentType = ', $parentType)"/>
+        </xsl:if>
+        
+        <xsl:choose>
+            <!-- First we just try to find if 'it' is there -->
+            <xsl:when test="$structureDefinition/f:StructureDefinition/f:snapshot/f:element/f:path/@value = $path">
+                <xsl:if test="$debug">
+                    <xsl:message select="concat('Found path: ', $path)"/>
+                </xsl:if>
+                <xsl:copy-of select="$structureDefinition/f:StructureDefinition/f:snapshot/f:element[f:path/@value = $path]"/>
+            </xsl:when>
+            <!-- Then, we try to replace the path of the element's parent with the type of that parent and try again -->
+            <xsl:when test="$parentPath and $structureDefinition/f:StructureDefinition/f:snapshot/f:element/f:path/@value = replace($path, $parentPath, $parentType)">
+                <xsl:if test="$debug">
+                    <xsl:message select="concat('Found path: ', replace($path, $parentPath, $parentType))"/>
+                </xsl:if>
+                <xsl:copy-of select="$structureDefinition/f:StructureDefinition/f:snapshot/f:element[f:path/@value = replace($path, $parentPath, $parentType)]"/>
+            </xsl:when>
+            <!-- If we cannot find an elementdefinition because it is some kind of unknown extension, we should handle that -->
+            <!--<xsl:when test="self::f:extension"></xsl:when>-->
+            <xsl:otherwise>
+                <xsl:message terminate="yes">Could not find elementDefinition for <xsl:value-of select="$path"/></xsl:message>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template match="*">
+        <xsl:element name="TODO:{local-name()}">
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+    
+</xsl:stylesheet>


### PR DESCRIPTION
Per discussion with Alexander: try to not repeat the mistakes of earlier and just 'get something out there' for you to see, review, perhaps use, expand upon, etc.

In a session with Niek we created a profile by hand (or using Forge), which resulted in the following execution:
https://touchstone.aegis.net/touchstone/scriptexecution?exec=202208311007574346710307&qn=/FHIRSandbox/Nictiz/dev/FHIR4-0-1-Test/PatientCorrections-1-0/PHR-Client/patientcorrections-phr-1-send-one-correctionrequest#WAITING_OPER

I used https://github.com/Nictiz/Nictiz-testscripts/blob/main/dev/FHIR4-0-1-Test/PatientCorrections-1-0/_reference/resources-specific/dwv-Transaction-Scenario-1.xml as input (`in/dwz-Transaction-Scenario-1.xml`). `in/` also contains our manual work as 'expected output' and a snapshot of the profile being used as reference, although the XSLT downloads the snapshot automatically from Simplifier given a package name and version.

The `out/` folder contains de output profile being generated at the moment. It is not identical to te reference input, but I placed some comments in the reference input to 'justify' the differences.

The XSLT itself (nothing fancy ANTy yet, just Input -> XSLT -> Output at the moment) is rich in comments with thoughts, explanations and caveats. It is build to terminate if it stumbles across something it doesn't know (yet). It reuses (hopefully upcycles) work of the content asserts phase of this project.

How to move forward? In my opinion:
- More input gives more output. It would be nice to have some more fixtures with manually made profiles to serve as test material
- On the other hand, during developing all kinds of different scenario's pop up. It would be nice to develop some sort of test folder with all kinds of edge cases.
- It would be nice to 'test' the error messages in Touchstone. This means for every fixture we generate a matching profile from, an 'unhappy flow' fixture should be created to see what kind of error Touchstone throws and if that is understandable for implementers.

I have not done anything with generating constraints (invariants) yet, but I imagine this could involve some work generating FHIRpath expressions. Please note that I have 'something like that' laying around which I used so generate content asserts, I suppose that could be recycled.