### PR TITLE
release 2.1.2

### DIFF
--- a/generate/README.md
+++ b/generate/README.md
@@ -295,7 +295,7 @@ The following optional parameters may be used:
   targets.additional=Cert-with-setup
   ```
   The TestScript resources can use the `nts:in-targets` to define which element should be included in a target (see above). Multiple extra targets may be separated using comma's.
-  Note: additional targets may only be defined on input folders, not on subfolders. If there are subfolders in the input folder, each variant of the input folder will contain the full set of subfolders (but with slightly different content, of course).  
+  Note: if there are subfolders in the folder on which an additional target is defined, each variant of the input folder will contain the full set of subfolders (but with slightly different content, of course).  
 - `version.addition`: a string that will be added verbatim to the value in the `TestScript.version` from the input file. If this element is absent, it will be populated with this value. 
 
 ### Building multiple projects
@@ -316,6 +316,10 @@ It can be found at `schematron/NictizTestScript.sch` relative to this README.
 Because of the verbosity of the ANT build, the logging level is set to 1 (warning) and Saxon is set to not try to recover. When more verbose output is wanted, the logging level can be changed by setting the `-DoutputLevel=` parameter on the ANT build.
 
 ## Changelog
+
+### 2.1.2
+- Fixed a bug where 'special characters' in a local path would lead to the LoadResources outputting this local path instead of a relative path.
+- Allow for additional targets being defined at a lower level than the input folder.
 
 ### 2.1.1
 - Changed some CodeSystem uris from STU3 to their R4 counterpart.

--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -467,7 +467,7 @@
                                                 <not>
                                                     <equals arg1="${nts.file.reldir.root}" arg2=""/>
                                                 </not>
-                                                <contains string="/@{target.dir}" substring="${nts.file.reldir.root}"/>
+                                                <contains string="/@{target.dir}" substring="${nts.file.reldir.root}-"/>
                                             </and>
                                             <then>
                                                 <sequential>

--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -413,6 +413,7 @@
                                     <!-- Get the relative directory of the input file within the base directory -->
                                     <local name="nts.file.reldir"/>
                                     <local name="nts.file.dir"/>
+                                    <local name="nts.file.reldir.leaf"/>
                                     <dirname property="nts.file.dir" file="@{nts.file}"/>
                                     <pathconvert property="nts.file.reldir" targetos="unix">
                                         <path>
@@ -424,18 +425,32 @@
                                         <map from="${input.dir.abs}" to=""/>
                                     </pathconvert>
                                     
-                                    <!-- Now extract the root dir of the relative path, where additional targets may be
-                                         defined, and any subpaths following it. -->
-                                    <propertyregex property="nts.file.reldir.root" override="true"
-                                        input="${nts.file.reldir}"
-                                        regexp="(\/[^\/]+)\/"
-                                        select="\1"
-                                        defaultValue="${nts.file.reldir}"/>
-                                    <propertyregex property="nts.file.reldir.leaf" override="true"
-                                        input="${nts.file.reldir}"
-                                        regexp="\/[^\/]+(\/.*)"
-                                        select="\1"
-                                        defaultValue=""/>
+                                    <!-- Now extract the 'root' dir of the relative path, where additional targets may be
+                                         defined, and any subpaths following it. The 'root' is the larget combination of dir and subdirs that are defined in target.additional -->
+                                    <var name="nts.file.reldir.root" value=""/>
+                                    <for list="${nts.file.reldir}" param="dirname" delimiter="/">
+                                        <sequential>
+                                            <local name="root.candidate"/>
+                                            <!-- Get relative path up to and including subdir.-->
+                                            <propertyregex property="root.candidate" input="${nts.file.reldir}" regexp="(\/.*\/@{dirname})" select="\1" defaultValue="/@{dirname}"/>
+                                            <!-- If the candidate is present in the target dir, pass the candidate. If not (for example because we are a level deeper), keep the last set candidate -->
+                                            <if>
+                                                <contains string="/@{target.dir}" substring="${root.candidate}"/>
+                                                <then>
+                                                    <var name="nts.file.reldir.root" value="${root.candidate}"/>
+                                                </then>
+                                                <else>
+                                                    <var name="nts.file.reldir.root" value="${nts.file.reldir.root}"/>
+                                                </else>
+                                            </if>
+                                        </sequential>
+                                    </for>
+                                    <pathconvert property="nts.file.reldir.leaf" targetos="unix">
+                                        <path path="${nts.file.reldir}"/>
+                                        <map from="${nts.file.reldir.root}" to=""/>
+                                        <map from="c:${nts.file.reldir.root}" to=""/>
+                                    </pathconvert>
+                                    
                                     <if>
                                         <!-- The default target -->
                                         <equals arg1="@{target.dir}" arg2="#default"/>
@@ -447,7 +462,13 @@
                                         </then>
                                         <elseif>
                                             <!-- An extra defined target -->
-                                            <contains string="/@{target.dir}" substring="${nts.file.reldir.root}"/>
+                                            <and>
+                                                <!-- Necessary because we explicitly set root to '' (empty string) every time) -->
+                                                <not>
+                                                    <equals arg1="${nts.file.reldir.root}" arg2=""/>
+                                                </not>
+                                                <contains string="/@{target.dir}" substring="${nts.file.reldir.root}"/>
+                                            </and>
                                             <then>
                                                 <sequential>
                                                     <!-- Extract the target name from the relative path name -->

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -33,7 +33,7 @@
                     </xsl:when>
                 </xsl:choose>
             </xsl:variable>
-            <xsl:value-of select="if (ends-with($fileUrl, '/')) then $fileUrl else concat($fileUrl, '/')"/>
+            <xsl:value-of select="encode-for-uri(if (ends-with($fileUrl, '/')) then $fileUrl else concat($fileUrl, '/'))"/>
         </xsl:variable>
         
         <!-- Make sure the referenceBase ends with a slash. -->

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -2,18 +2,18 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" xmlns:f="http://hl7.org/fhir" exclude-result-prefixes="#all" version="2.0">
     <!-- Stylesheet to write out the special TestScript resource that is used to load all fixtures to the test 
          server (the load script) -->
-
+    
     <xsl:output indent="yes" omit-xml-declaration="yes"/>
-
+    
     <!-- The path to the base folder of fixtures, relative to the output. Defaults to '../_reference'. -->
     <xsl:param name="referenceBase" select="'../_reference/'"/>
     
     <!-- The absolute path to the folder of fixtures -->
     <xsl:param name="referenceDir"/>
-        
+    
     <!-- Comma-separated list of paths to exclude -->
     <xsl:param name="loadResourcesExclude"/>
-
+    
     <xsl:template match="/">
         
         <!-- Convert the reference to a file:// URL and make sure it ends with a slash. -->
@@ -33,7 +33,8 @@
                     </xsl:when>
                 </xsl:choose>
             </xsl:variable>
-            <xsl:value-of select="encode-for-uri(if (ends-with($fileUrl, '/')) then $fileUrl else concat($fileUrl, '/'))"/>
+            <!-- escape-html-uri is better suited then encode-uri, but spaces are left so they are handled separately -->
+            <xsl:value-of select="replace(escape-html-uri(if (ends-with($fileUrl, '/')) then $fileUrl else concat($fileUrl, '/')), ' ', '%20')"/>
         </xsl:variable>
         
         <!-- Make sure the referenceBase ends with a slash. -->
@@ -43,8 +44,8 @@
         <xsl:variable name="fixtures" as="item()*">
             <xsl:variable name="exclusionPatterns" select="
                 let $pathNormalized  := translate($loadResourcesExclude,'\','/'),
-                    $regexEscaped    := replace($pathNormalized, '(\.|\[|\]|\\|\||\-|\^|\$|\?|\+|\{|\}|\(|\))','\\$1'), (: all regex characters except * :)
-                    $wildCardAsRegex := replace($regexEscaped,'\*','.*?')
+                $regexEscaped    := replace($pathNormalized, '(\.|\[|\]|\\|\||\-|\^|\$|\?|\+|\{|\}|\(|\))','\\$1'), (: all regex characters except * :)
+                $wildCardAsRegex := replace($regexEscaped,'\*','.*?')
                 return for $pattern in tokenize($wildCardAsRegex,',') 
                 return normalize-space($pattern)"/>
             <xsl:variable name="fixturesUnfiltered" select="collection(iri-to-uri(concat(resolve-uri($referenceDirAsUrl), '?select=', '*.xml;recurse=yes')))/f:*[not(contains(f:id/@value, 'Bearer'))]"/>
@@ -63,134 +64,134 @@
         
         <xsl:choose>
             <xsl:when test="$fixtures">
-        <!-- Write out the TestScript resource -->
-        <TestScript xmlns="http://hl7.org/fhir">
-            <id value="resources-purgecreateupdate-xml"/>
-            <url value="http://nictiz.nl/fhir/TestScript/load-resources-purgecreateupdate-xml"/>
-            <name value="Load Test Resources - Purge Create Update - XML"/>
-            <status value="active"/>
-            <publisher value="Nictiz"/>
-            <contact>
-                <name value="MedMij"/>
-                <telecom>
-                    <system value="email"/>
-                    <value value="kwalificatie@nictiz.nl"/>
-                    <use value="work"/>
-                </telecom>
-            </contact>
-            <description value="Load test resources using the update (PUT) operation of the target FHIR server for use in testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
-            <copyright value="© Nictiz 2020"/>
-            
-            <!-- Write out all fixture references -->
-            <xsl:for-each select="$fixtures">
-                <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
-                <xsl:variable name="fixtureId">
-                    <xsl:call-template name="generateFixtureId"/>
-                </xsl:variable>
-                <fixture id="{$fixtureId}">
-                    <autocreate value="false"/>
-                    <autodelete value="false"/>
-                    <resource>
-                        <reference value="{replace(document-uri(ancestor::node()), $referenceDirAsUrl, $referenceBaseSanitized)}"/>
-                    </resource>
-                </fixture>
-            </xsl:for-each>
-            
-            <!-- Write out variables that read the id's from all fixtures -->
-            <xsl:for-each select="$fixtures">
-                <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
-                <xsl:variable name="fixtureId">
-                    <xsl:call-template name="generateFixtureId"/>
-                </xsl:variable>
-                <variable>
-                    <name value="{$fixtureId}-id"/>
-                    <expression value="{local-name(.)}.id"/>
-                    <sourceId value="{$fixtureId}"/>
-                </variable>
-            </xsl:for-each>
-            
-            <!-- variable T -->
-            <variable>
-                <name value="T"/>
-                <defaultValue value="${{CURRENTDATE}}"/>
-                <description value="Date that data and queries are expected to be relative to."/>
-            </variable>
-            
-            <!-- Purge Patients in setup -->
-            <setup>
-                <xsl:for-each select="$tokens">
-                    <action>
-                        <operation>
-                            <type>
-                                <system value="http://touchstone.com/fhir/extended-operation-codes"/>
-                                <code value="purge"/>
-                            </type>
-                            <resource value="Patient"/>
-                            <accept value="xml"/>
-                            <contentType value="xml"/>
-                            <encodeRequestUrl value="true"/>
-                            <params value="{tokenize(substring-before(base-uri(), '-token.xml'), '/')[last()]}/$purge"/>
-                            <requestHeader>
-                                <field value="Authorization"/>
-                                <value value="{f:id/@value}"/>
-                            </requestHeader>
-                        </operation>
-                    </action>
-                    <action>
-                        <assert>
-                            <description
-                                value="Confirm that the returned HTTP status is 200(OK) or 204(No Content)"/>
-                            <operator value="in"/>
-                            <responseCode value="200,204"/>
-                            <warningOnly value="false"/>
-                        </assert>
-                    </action>
-                </xsl:for-each>
-            </setup>
-            
-            <!-- PUT all fixtures in test -->
-            <test id="Step1-LoadTestResourceCreate">
-                <name value="Step1-LoadTestResourceCreate"/>
-                <description value="Load test resources using the update (PUT) operation of the target FHIR server for use in testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
-                <xsl:for-each select="$fixtures">
-                    <!-- Load Patient resources first to make sure WildFHIR indexes data in the right order to use patient.identifier searches. -->
-                    <xsl:sort data-type="number" order="ascending" select="(number(local-name() = 'Patient') * 1) + (number(not(local-name() = 'Patient')) * 2)"/>
-                    <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
-                    <xsl:variable name="fixtureId">
-                        <xsl:call-template name="generateFixtureId"/>
-                    </xsl:variable>
-                    <action>
-                        <operation>
-                            <type>
-                                <system value="http://terminology.hl7.org/CodeSystem/testscript-operation-codes"/>
-                                <code value="updateCreate"/>
-                            </type>
-                            <resource value="{local-name(.)}"/>
-                            <accept value="xml"/>
-                            <contentType value="xml"/>
-                            <encodeRequestUrl value="true"/>
-                            <params value="/${{{$fixtureId}-id}}"/>
-                            <requestHeader>
-                                <field value="Authorization"/>
-                                <!-- This Bearer token is a dedicated token for LoadResources purposes -->
-                                <!--<value value="Bearer e317fc02-e8ff-40fe-9b22-f3c43fbf5613"/>-->
-                                <!-- Use first patient token until dedicated Bearer token is active -->
-                                <value value="{$tokens[1]/f:id/@value}"/>
-                            </requestHeader>
+                <!-- Write out the TestScript resource -->
+                <TestScript xmlns="http://hl7.org/fhir">
+                    <id value="resources-purgecreateupdate-xml"/>
+                    <url value="http://nictiz.nl/fhir/TestScript/load-resources-purgecreateupdate-xml"/>
+                    <name value="Load Test Resources - Purge Create Update - XML"/>
+                    <status value="active"/>
+                    <publisher value="Nictiz"/>
+                    <contact>
+                        <name value="MedMij"/>
+                        <telecom>
+                            <system value="email"/>
+                            <value value="kwalificatie@nictiz.nl"/>
+                            <use value="work"/>
+                        </telecom>
+                    </contact>
+                    <description value="Load test resources using the update (PUT) operation of the target FHIR server for use in testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
+                    <copyright value="© Nictiz 2020"/>
+                    
+                    <!-- Write out all fixture references -->
+                    <xsl:for-each select="$fixtures">
+                        <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
+                        <xsl:variable name="fixtureId">
+                            <xsl:call-template name="generateFixtureId"/>
+                        </xsl:variable>
+                        <fixture id="{$fixtureId}">
+                            <autocreate value="false"/>
+                            <autodelete value="false"/>
+                            <resource>
+                                <reference value="{replace(document-uri(ancestor::node()), $referenceDirAsUrl, $referenceBaseSanitized)}"/>
+                            </resource>
+                        </fixture>
+                    </xsl:for-each>
+                    
+                    <!-- Write out variables that read the id's from all fixtures -->
+                    <xsl:for-each select="$fixtures">
+                        <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
+                        <xsl:variable name="fixtureId">
+                            <xsl:call-template name="generateFixtureId"/>
+                        </xsl:variable>
+                        <variable>
+                            <name value="{$fixtureId}-id"/>
+                            <expression value="{local-name(.)}.id"/>
                             <sourceId value="{$fixtureId}"/>
-                        </operation>
-                    </action>
-                    <action>
-                        <assert>
-                            <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
-                            <operator value="in"/>
-                            <responseCode value="200,201"/>
-                            <warningOnly value="false"/>
-                        </assert>
-                    </action>
-                </xsl:for-each>
-            </test>
-        </TestScript>
+                        </variable>
+                    </xsl:for-each>
+                    
+                    <!-- variable T -->
+                    <variable>
+                        <name value="T"/>
+                        <defaultValue value="${{CURRENTDATE}}"/>
+                        <description value="Date that data and queries are expected to be relative to."/>
+                    </variable>
+                    
+                    <!-- Purge Patients in setup -->
+                    <setup>
+                        <xsl:for-each select="$tokens">
+                            <action>
+                                <operation>
+                                    <type>
+                                        <system value="http://touchstone.com/fhir/extended-operation-codes"/>
+                                        <code value="purge"/>
+                                    </type>
+                                    <resource value="Patient"/>
+                                    <accept value="xml"/>
+                                    <contentType value="xml"/>
+                                    <encodeRequestUrl value="true"/>
+                                    <params value="{tokenize(substring-before(base-uri(), '-token.xml'), '/')[last()]}/$purge"/>
+                                    <requestHeader>
+                                        <field value="Authorization"/>
+                                        <value value="{f:id/@value}"/>
+                                    </requestHeader>
+                                </operation>
+                            </action>
+                            <action>
+                                <assert>
+                                    <description
+                                        value="Confirm that the returned HTTP status is 200(OK) or 204(No Content)"/>
+                                    <operator value="in"/>
+                                    <responseCode value="200,204"/>
+                                    <warningOnly value="false"/>
+                                </assert>
+                            </action>
+                        </xsl:for-each>
+                    </setup>
+                    
+                    <!-- PUT all fixtures in test -->
+                    <test id="Step1-LoadTestResourceCreate">
+                        <name value="Step1-LoadTestResourceCreate"/>
+                        <description value="Load test resources using the update (PUT) operation of the target FHIR server for use in testing. All resource ids are pre-defined. The target XIS FHIR server is expected to support resource create via the update (PUT) operation for client assigned ids. "/>
+                        <xsl:for-each select="$fixtures">
+                            <!-- Load Patient resources first to make sure WildFHIR indexes data in the right order to use patient.identifier searches. -->
+                            <xsl:sort data-type="number" order="ascending" select="(number(local-name() = 'Patient') * 1) + (number(not(local-name() = 'Patient')) * 2)"/>
+                            <xsl:sort select="lower-case(concat(local-name(), '-', f:id/@value))"/>
+                            <xsl:variable name="fixtureId">
+                                <xsl:call-template name="generateFixtureId"/>
+                            </xsl:variable>
+                            <action>
+                                <operation>
+                                    <type>
+                                        <system value="http://terminology.hl7.org/CodeSystem/testscript-operation-codes"/>
+                                        <code value="updateCreate"/>
+                                    </type>
+                                    <resource value="{local-name(.)}"/>
+                                    <accept value="xml"/>
+                                    <contentType value="xml"/>
+                                    <encodeRequestUrl value="true"/>
+                                    <params value="/${{{$fixtureId}-id}}"/>
+                                    <requestHeader>
+                                        <field value="Authorization"/>
+                                        <!-- This Bearer token is a dedicated token for LoadResources purposes -->
+                                        <!--<value value="Bearer e317fc02-e8ff-40fe-9b22-f3c43fbf5613"/>-->
+                                        <!-- Use first patient token until dedicated Bearer token is active -->
+                                        <value value="{$tokens[1]/f:id/@value}"/>
+                                    </requestHeader>
+                                    <sourceId value="{$fixtureId}"/>
+                                </operation>
+                            </action>
+                            <action>
+                                <assert>
+                                    <description value="Confirm that the returned HTTP status is 200(OK) or 201(Created)."/>
+                                    <operator value="in"/>
+                                    <responseCode value="200,201"/>
+                                    <warningOnly value="false"/>
+                                </assert>
+                            </action>
+                        </xsl:for-each>
+                    </test>
+                </TestScript>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:message>No LoadResources to generate</xsl:message>
@@ -207,7 +208,7 @@
         <xsl:if test="not(matches(f:id/@value, '^[A-Za-z0-9\-\.]{1,64}$'))">
             <xsl:message terminate="yes" select="concat('Invalid FHIR id: ', f:id/@value)"/>
         </xsl:if>
-
+        
         <xsl:variable name="fixtureId" select="concat(local-name(), '-', f:id/@value)"/>
         <xsl:choose>
             <xsl:when test="matches($fixtureId, '^[A-Za-z0-9\-\.]{1,64}$')">


### PR DESCRIPTION
- Fixed a bug where 'special characters' in a local path would lead to the LoadResources outputting this local path instead of a relative path. Foppe used a local OneDrive folder on his Furore device (containing spaces) where this came forward.
- Changes the way nts.file.reldir.root (and .leaf) are determined to allow for additional targets being defined at a lower level than `[standard]/[level1]`, also allowing `[standard]/[level1]/[level2]` (and even deeper). For MP9 we have and additional transaction subdivision (`MP9-2-0-0/MedicationData/Retrieve` for example) and we would like to create additional targets at that level. targets.additional would be defined like `targets.additional=MedicationData/Serve-Nictiz-intern,...`

Edit: tested this in the MP9-2-0-0 branch and in PDFA-3-0.