### PR TITLE
Use qualification tokens json

### DIFF
--- a/generate/README.md
+++ b/generate/README.md
@@ -379,7 +379,7 @@ Because of the verbosity of the ANT build, the logging level is set to 1 (warnin
 ## Changelog
 
 ### 2.5.0
-- Add the tags `<nts:authToken/>` and `<nts:authHeader/>` to work with authorization tokens defined in a JSON file, as is expected for mock authentication on Touchstone. This supersedes the `<nts:patientTokenFixture/>` tag.
+- Add the tag `<nts:authToken/>` to work with authorization tokens defined in a JSON file, as is expected for mock authentication on Touchstone. This supersedes the `<nts:patientTokenFixture/>` tag.
 
 ### 2.4.1
 - Make the magic _FORMAT parameter available to nts:ifset

--- a/generate/README.md
+++ b/generate/README.md
@@ -204,30 +204,49 @@ It is also possible implicitly declare the rule when it is used by adding the `h
 </assert>  
 ```
 
-### Patient token and date T
+### Date T and authorization headers
 
-There are two special elements for use cases that are common across Nictiz test scripts.
+There are special elements for two use cases that are common across Nictiz test scripts.
 
-The first one for including the patient authorization token in the TestScript:
-
-```xml
-<nts:patientTokenFixture href="..">
-```
-
-The `href` attribute should point to the `Patient` instance containing the token, as is commonly done with the Nictiz test scripts, placed in the "_reference"-folder. The `nts:scenario` attribute on the TestScript root determines how this tag is expanded:
-
-* for "server", a variable will be created which the test script executor can set, defaulting to the value from the fixture.
-* for "client", the fixture will be included and a variable called "patient-token-id" will be created that reads the value from the fixture
-
-The token filename should end with `token.xml` and the token id should start with `Bearer`.
-
-The second element is to indicate that the "date T" variable should be defined for the testscript:
+The first one is to indicate that the "date T" variable should be defined for the TestScript:
 
 ```xml
 <nts:includeDateT value="yes|no">
 ```
 
 If this element is present, and `value` is absent or set to "yes", a variable for setting date T will be included in the TestScript.
+
+The second one deals with the authorization header for defining the patient context in the TestScript. The assumption here is that the (static) content of an `Authorization` header associated with a specific Patient resource `.id` is defined in a JSON file with the following syntax:
+```json
+{
+    "accessToken": "Bearer ...",
+    "resourceId": "[resource.id of Patient resource]",
+}
+```
+
+This file should be passed as the `tokens.json` parameter to the build script. The token can then be imported into a TestScript using:
+
+```xml
+<nts:authToken patientResourceId="[resource.id of Patient resource]"/>
+```
+
+and subsequently be used in `.operation`'s with:
+
+```xml
+<nts:authHeader>
+```
+
+The output of these tags depend on the `nts:scenario`. For client scripts, the access token will be hardcoded in the `.operation`'s. For server scripts, a TestScript variable will be defined that defaults to the access token, but which can be overruled by the tester. This variable will be used in the `Authorization` header.
+
+These tags support an optional `id` attribute to match the `<nts:authToken/>` tags to the `<nts:authHeader/>` tags. This is useful when multiple tokens need to be handled. This `id` is also the name of the TestScript variable that is being defined in server scripts. When `id` is absent, this will have the value `patient-token-id`.
+
+There is actually a second (outdated) mechanism to import authorization tokens:
+
+```xml
+<nts:patientTokenFixture href="..">
+```
+
+The `href` attribute should point to a `Patient` instance containing the content of the authorization header as its `.id`, placed in the "_reference"-folder and with a file name ending in `-token.xml`. There is no corresponding tag to use the imported header in `.operation`'s, but a TestScript variable called `patient-token-id` will be defined which can be used throughout the TestScript.
 
 ### Scenario: server (xis) or client (phr)
 

--- a/generate/README.md
+++ b/generate/README.md
@@ -227,18 +227,20 @@ The second one deals with the authorization header for defining the patient cont
 This file should be passed as the `tokens.json` parameter to the build script. The token can then be imported into a TestScript using:
 
 ```xml
-<nts:authToken patientResourceId="[resource.id of Patient resource]"/>
+<nts:authToken patientResourceId="[resource.id of Patient resource]" {id="[patient-token-id]"}/>
 ```
 
-and subsequently be used in `.operation`'s with:
+This sets an NTS parameter with the specified `id`, which can then be used throughout the NTS file. `id` is usually omitted, in which case it defaults to "patient-token-id". 
 
+For example, if you included a token with id "patient-token-id", you can use it to define the Authorization header with: 
 ```xml
-<nts:authHeader>
+<requestHeader>
+  <field value="Authorization"/>
+  <value value="{$patient-token}"/>  
+</requestHeader>
 ```
 
-The output of these tags depend on the `nts:scenario`. For client scripts, the access token will be hardcoded in the `.operation`'s. For server scripts, a TestScript variable will be defined that defaults to the access token, but which can be overruled by the tester. This variable will be used in the `Authorization` header.
-
-These tags support an optional `id` attribute to match the `<nts:authToken/>` tags to the `<nts:authHeader/>` tags. This is useful when multiple tokens need to be handled. This `id` is also the name of the TestScript variable that is being defined in server scripts. When `id` is absent, this will have the value `patient-token-id`.
+The output depends on `nts:scenario`. For client scripts, the content of the access token will be hardcoded in the TestScript output. For server scripts, a TestScript variable will be defined that defaults to the access token, but which can be overruled by the tester. The NTS variable will be translated to this TestScript variable.
 
 There is actually a second (outdated) mechanism to import authorization tokens:
 
@@ -246,7 +248,7 @@ There is actually a second (outdated) mechanism to import authorization tokens:
 <nts:patientTokenFixture href="..">
 ```
 
-The `href` attribute should point to a `Patient` instance containing the content of the authorization header as its `.id`, placed in the "_reference"-folder and with a file name ending in `-token.xml`. There is no corresponding tag to use the imported header in `.operation`'s, but a TestScript variable called `patient-token-id` will be defined which can be used throughout the TestScript.
+The `href` attribute should point to a `Patient` instance containing the content of the authorization header as its `.id`, placed in the "_reference"-folder and with a file name ending in `-token.xml`. This will always result in definig the TestScript variable `patient-token-id`, for both client and server scripts.
 
 ### Scenario: server (xis) or client (phr)
 

--- a/generate/README.md
+++ b/generate/README.md
@@ -376,6 +376,12 @@ Because of the verbosity of the ANT build, the logging level is set to 1 (warnin
 
 ## Changelog
 
+### 2.5.0
+- Add the tags `<nts:authToken/>` and `<nts:authHeader/>` to work with authorization tokens defined in a JSON file, as is expected for mock authentication on Touchstone. This supersedes the `<nts:patientTokenFixture/>` tag.
+
+### 2.4.1
+- Make the magic _FORMAT parameter available to nts:ifset
+
 ### 2.4.0
 - Add an extra script to convert XML fixtures to JSON. This can be used separately or in conjunction with the NTS build script.
 

--- a/generate/ant/build-multiple.xml
+++ b/generate/ant/build-multiple.xml
@@ -26,6 +26,7 @@
                     <property name="lib.dir" value="${lib.dir}"/>
                     <property name="commoncomponents.dir" value="${commoncomponents.dir}"/>
                     <property name="version.addition" value="${version.addition}"/>
+                    <property name="tokens.json" value="${tokens.json}"/>
                 </ant>
             </sequential>
         </for>

--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -390,6 +390,7 @@
                     <param name="referenceBase" expression="${reference.dir.loadresourcesrelative.normalized}"/>
                     <param name="referenceDir" expression="${input.dir.abs}/${reference.subdir}/"/>
                     <param name="loadResourcesExclude" expression="${loadresources.exclude}"/>
+                    <param name="tokensJsonFile" expression="${tokens.json.url}"/>
                 </parameters>
             </saxon-transform>
             

--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -17,6 +17,7 @@
     - lib.dir                 : The directory where all build dependency's will be placed. It's a good idea to add this to
                                 .gitignore.
     - [components.dir]        : Optional - the directory containing the project components, relative to input.dir. Defaults to '_components'.
+    - [tokens.json]           : Optional - the relative path to a JSON file linking Patient resource id's to authorization tokens. This is a feature specifically for the mocked authorization mechanism on Touchstone.
     - [loadresources.exclude] : Optional - A relative path to a folder containing the fixtures or to specific filenames to be excluded from 
                                 the LoadResources script. Multiple entries can be comma separated. `*` is accepted as a wildcard.
     - [processfixtures.skip]  : Optional - If 'true' (or any other non-empty value) processing fixtures is skipped.
@@ -53,6 +54,12 @@
     <property name="components.dir.abs"       location="${components.dir}"/>
     <property name="commoncomponents.dir.abs" location="${commoncomponents.dir}"/>
     <property name="reference.subdir"         value="_reference"/>
+    
+    <!-- Construct a file URL to the tokens JSON file. -->
+    <pathconvert property="tokens.json.url" targetos="unix">
+        <path location="${tokens.json}"/>
+        <mapper type="regexp" from="(.*)" to="file:/\1"/>
+    </pathconvert>
     
     <!-- Try to read all project property's defined in build.properties -->
     <property file="${input.dir.abs}/build.properties"/>
@@ -236,6 +243,7 @@
                                     <param name="expectedResponseFormat" expression="@{expectedResponseFormat}"/>
                                     <param name="target" expression="@{target}"/>
                                     <param name="versionAddition" expression="${version.addition}"/>
+                                    <param name="tokensJsonFile" expression="${tokens.json.url}"/>
                                 </parameters>
                             </saxon-transform>
                             
@@ -253,6 +261,7 @@
                             <param name="projectComponentFolder" expression="${components.dir.abs}"/>
                             <param name="target" expression="@{target}"/>
                             <param name="versionAddition" expression="${version.addition}"/>
+                            <param name="tokensJsonFile" expression="${tokens.json.url}"/>
                         </parameters>
                     </saxon-transform>
                     <collect-references testscript.path="@{output.dir}/${nts.file.newname}" references.file="@{references.file}" reference.dir.rel="@{reference.dir.rel}"/>

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -68,9 +68,6 @@
             </xsl:choose>
         </xsl:variable>
         
-        <!-- And collect all bearer fixtures as file URLs -->
-        <xsl:variable name="tokens" select="collection(iri-to-uri(concat(resolve-uri($referenceDirAsUrl), '?select=', '*token.xml;recurse=yes')))/f:*"/>
-        
         <xsl:choose>
             <xsl:when test="$fixtures">
                 <!-- Write out the TestScript resource -->
@@ -135,16 +132,16 @@
                             <xsl:value-of select="substring(./@value, 9)"/>
                         </xsl:for-each>
                     </xsl:variable>
-                    <!-- ... and find the matching tokens. -->
+                    <!-- ... and find the matching tokens, if they exists in the JSON file. -->
                     <xsl:variable name="tokens" as="element(nts:authToken)*">
                         <xsl:for-each select="distinct-values($patientReferences)">
-                            <xsl:copy-of select="nts:resolveAuthToken(., '')"/>
+                            <xsl:copy-of select="nts:resolveAuthToken(., '', false())"/>
                         </xsl:for-each>
                     </xsl:variable>
                     
                     <!-- Purge Patients in setup -->
                     <setup>
-                        <xsl:for-each select="$tokens">
+                        <xsl:for-each select="$tokens[@token]">
                             <action>
                                 <operation>
                                     <type>
@@ -202,12 +199,12 @@
                                         <field value="Authorization"/>
                                         <!-- KT-330: In MedMij R4, it is required to use the correct patient token for updateCreate of Patients, but it doesn't hurt for STU3 -->
                                         <xsl:choose>
-                                            <xsl:when test="$tokens[@resourceId = $resourceId]">
-                                                <value value="{$tokens[@resourceId = $resourceId]/@token}"/>
+                                            <xsl:when test="$tokens[@token and @resourceId = $resourceId]">
+                                                <value value="{$tokens[@token and @resourceId = $resourceId]/@token}"/>
                                             </xsl:when>
                                             <xsl:otherwise>
                                                 <!-- Use first patient token, or should we check fixture .subject to determine correct token? -->
-                                                <value value="{$tokens[1]/@token}"/>
+                                                <value value="{$tokens[@token][1]/@token}"/>
                                             </xsl:otherwise>
                                         </xsl:choose>
                                     </requestHeader>

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -138,7 +138,7 @@
                     <!-- ... and find the matching tokens. -->
                     <xsl:variable name="tokens" as="element(nts:authToken)*">
                         <xsl:for-each select="distinct-values($patientReferences)">
-                            <xsl:copy-of select="nts:resolveAuthToken('', .)"/>
+                            <xsl:copy-of select="nts:resolveAuthToken(., '')"/>
                         </xsl:for-each>
                     </xsl:variable>
                     

--- a/generate/xslt/generateLoadResources.xsl
+++ b/generate/xslt/generateLoadResources.xsl
@@ -212,12 +212,12 @@
                                         <field value="Authorization"/>
                                         <!-- KT-330: In MedMij R4, it is required to use the correct patient token for updateCreate of Patients, but it doesn't hurt for STU3 -->
                                         <xsl:choose>
-                                            <xsl:when test="$tokens[@token and @resourceId = $resourceId]">
-                                                <value value="{$tokens[@token and @resourceId = $resourceId]/@token}"/>
+                                            <xsl:when test="$tokens[@token != '' and @patientResourceId = $resourceId]">
+                                                <value value="{$tokens[@token != '' and @patientResourceId = $resourceId]/@token}"/>
                                             </xsl:when>
                                             <xsl:otherwise>
                                                 <!-- Use first patient token, or should we check fixture .subject to determine correct token? -->
-                                                <value value="{$tokens[@token][1]/@token}"/>
+                                                <value value="{$tokens[@token != ''][1]/@token}"/>
                                             </xsl:otherwise>
                                         </xsl:choose>
                                     </requestHeader>

--- a/generate/xslt/generateTestScript.xsl
+++ b/generate/xslt/generateTestScript.xsl
@@ -33,7 +33,12 @@
          input, it will be set to this parameter. -->
     <xsl:param name="versionAddition" select="''"/>
     
-    <xsl:param name="tokensJsonFile" select="'file:/C:/Users/Edelman/Nictiz-testscripts/Configuration/QualificationTokens.json'"/>
+    <!-- Optional URL to a JSON file matching Patient resource id's to tokens used in authorization headers. This
+         parameter is needed if the nts:authToken/nts:authHeader features are used. In addition, the two concepts
+         are linked by placing them in the same group with the keys 'resourceId' and 'accessToken'. This is a
+         structure imposed by Touchstone for mocking token based authorization.
+    -->
+    <xsl:param name="tokensJsonFile"/>
     
     <!-- The main template, which will call the remaining templates. -->
     <xsl:template name="generate" match="f:TestScript">
@@ -812,6 +817,9 @@
     <xsl:function name="nts:resolveAuthTokens" as="element(nts:authToken)*">
         <xsl:param name="authTokenElements" as="element(nts:authToken)*"/>
         
+        <xsl:if test="count($authTokenElements) &gt; 0 and not($tokensJsonFile)">
+            <xsl:message terminate="yes">If you use the nts:authToken element, you need to pass in a file containing the tokens using the tokensJsonFile parameter.</xsl:message>
+        </xsl:if>
         <xsl:if test="count($authTokenElements[not(@id)]) &gt; 1">
             <xsl:message terminate="yes">When using multiple nts:authToken elements, at most one may have the default id. All other instances must be uniquely identified with an id.</xsl:message>
         </xsl:if>

--- a/generate/xslt/generateTestScript.xsl
+++ b/generate/xslt/generateTestScript.xsl
@@ -66,7 +66,7 @@
         <xsl:variable name="authTokens" as="element(nts:authToken)*">
             <xsl:for-each select="//nts:authToken[@patientResourceId]">
                 <xsl:variable name="id" select="if (.[@id]) then ./@id else 'patient-token-id'"/>
-                <xsl:copy-of select="nts:resolveAuthToken(./@patientResourceId, $id)"/>
+                <xsl:copy-of select="nts:resolveAuthToken(./@patientResourceId, $id, true())"/>
             </xsl:for-each>
         </xsl:variable>
         

--- a/generate/xslt/generateTestScript.xsl
+++ b/generate/xslt/generateTestScript.xsl
@@ -1,7 +1,10 @@
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
     xmlns="http://hl7.org/fhir"
     xmlns:f="http://hl7.org/fhir"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions"
+    xmlns:array="http://www.w3.org/2005/xpath-functions/array"
+    xmlns:map="http://www.w3.org/2005/xpath-functions/map"
     xmlns:nts="http://nictiz.nl/xsl/testscript"
     exclude-result-prefixes="#all">
     <xsl:output method="xml" indent="yes"/>
@@ -374,6 +377,18 @@
                 </xsl:attribute>
             </xsl:otherwise>
         </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template match="nts:patientToken[@patientId]" mode="expand">
+        <xsl:variable name="resourceId" select="./@patientId"/>
+        <xsl:variable name="patientTokenMap" select="fn:json-doc('file:/C:/Users/Edelman/Nictiz-testscripts/Configuration/QualificationTokens.json')"/>
+        <xsl:variable name="patientTokenEntry" select="array:filter($patientTokenMap, function($x) {map:get($x, 'resourceId') = $resourceId})"/>
+        <xsl:variable name="patientToken" select="map:get($patientTokenEntry(1), 'accessToken')"/>
+
+        <variable>
+            <name value="patient-token-id"/>
+            <expression value="{$patientToken}"/>
+        </variable>
     </xsl:template>
     
     <!-- Expand an nts:patientTokenFixture element to create a variable called 'patient-token-id'. How this is handled

--- a/generate/xslt/generateTestScript.xsl
+++ b/generate/xslt/generateTestScript.xsl
@@ -63,7 +63,7 @@
         <xsl:if test="count(//nts:authToken[not(@id)]) &gt; 1">
             <xsl:message terminate="yes">When using multiple nts:authToken elements, at most one may have the default id. All other instances must be uniquely identified with an id.</xsl:message>
         </xsl:if>
-        <xsl:variable name="authTokens">
+        <xsl:variable name="authTokens" as="element(nts:authToken)*">
             <xsl:for-each select="//nts:authToken[@patientResourceId]">
                 <xsl:variable name="id" select="if (.[@id]) then ./@id else 'patient-token-id'"/>
                 <xsl:copy-of select="nts:resolveAuthToken(./@patientResourceId, $id)"/>
@@ -427,7 +427,7 @@
                     <xsl:message terminate="yes">An nts:authHeader element with 'patient-token-id' (the default when no id is set) was used, but no matching nts:authToken was defined.</xsl:message>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message terminate="yes" select="concat('An nts:authHeader element with id ''', $id, ''' was used, but no matching nts:authToken with the same id was defined.')"/>                    
+                    <xsl:message terminate="yes" select="concat('An nts:authHeader element with id ''', $id, ''' was used, but no matching nts:authToken with the same id was defined.')"/>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:if>

--- a/generate/xslt/resolveAuthTokens.xsl
+++ b/generate/xslt/resolveAuthTokens.xsl
@@ -16,14 +16,16 @@
          this operation unless/until it is actually needed. -->
     <xsl:variable name="patientTokenMap" select="unparsed-text($tokensJsonFile)"/>
     
-    <!-- Resolve the authorization token from the JSON file. If no token was found or multiple matching tokens exist,
-         an error is thrown.
+    <!-- Resolve the authorization token from the JSON file. If multiple matching tokens exist, an error is thrown.
          @param patientResourceId - the resource id of the Patient resource for which the token is resolved.
          @param id - an internal id to match the resolved token to a mnemonic for later use.
+         @param failOnMissing - a boolean to indicate that processing should be halted when the id cannot be resolved,
+                                or that the resulting attribute will be empty.
          @returns a list of nts:authToken XML elements with the parameters patientResourceId, token, and id. -->
     <xsl:function name="nts:resolveAuthToken" as="element(nts:authToken)?">
         <xsl:param name="patientResourceId" as="xs:string"/>
         <xsl:param name="id" as="xs:string"/>
+        <xsl:param name="failOnMissing" as="xs:boolean"/>
 
         <xsl:if test="not($tokensJsonFile)">
             <xsl:message terminate="yes">You're trying to resolve a token based on a Patient resource id, but didn't pass in a file containing the tokens using the tokensJsonFile parameter.</xsl:message>
@@ -48,7 +50,7 @@
         </xsl:variable>
 
         <xsl:choose>
-            <xsl:when test="count($patientToken) = 0">
+            <xsl:when test="count($patientToken) = 0 and $failOnMissing">
                 <xsl:message terminate="yes" select="concat('Couldn''t find access token for Patient resource ', $patientResourceId, ' in ', $tokensJsonFile)"/>
             </xsl:when>
             <xsl:when test="count($patientToken) &gt; 1">

--- a/generate/xslt/resolveAuthTokens.xsl
+++ b/generate/xslt/resolveAuthTokens.xsl
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:nts="http://nictiz.nl/xsl/testscript"
+    exclude-result-prefixes="xs"
+    version="2.0">
+    
+    <!-- Helper template to resolve authorization tokens from a JSON file, given the id of the Patient resource. The
+         two concepts are linked by placing them in the same group with the keys 'resourceId' and 'accessToken'. This
+         is a structure imposed by Touchstone for mocking token based authorization. -->
+    
+    <!-- The (file) URL to the JSON file matching Patient resource id's to tokens used in authorization headers. -->
+    <xsl:param name="tokensJsonFile"/>
+
+    <!-- Load the JSON file as flat text in the patientTokenMap variable. It is assumed that the XSLT processor defers
+         this operation unless/until it is actually needed. -->
+    <xsl:variable name="patientTokenMap" select="unparsed-text($tokensJsonFile)"/>
+    
+    <!-- Resolve the authorization token from the JSON file. If no token was found or multiple matching tokens exist,
+         an error is thrown.
+         @param patientResourceId - the resource id of the Patient resource for which the token is resolved.
+         @param id - an internal id to match the resolved token to a mnemonic for later use.
+         @returns a list of nts:authToken XML elements with the parameters patientResourceId, token, and id. -->
+    <xsl:function name="nts:resolveAuthToken" as="element(nts:authToken)?">
+        <xsl:param name="patientResourceId" as="xs:string"/>
+        <xsl:param name="id" as="xs:string"/>
+        
+        <!-- Try to find the "accessToken" key associated with "resourceId": patientId in the tokens JSON file.
+             This is done in two steps: first the block with the relevant resourceId is identified, and then the
+             "accessToken" value is extracted.
+             Note: this could be done using the JSON parsing features of XSLT 3, but at the moment of writing this
+             use case is too narrow to warrant the bump to XSLT 3. So a 'dumb' regex based method is used. -->
+        <xsl:variable name="patientToken" as="xs:string*">
+            <xsl:variable name="regex" select="concat('\{[^\}]*[''&quot;]resourceId[''&quot;]\s*:\s*[''&quot;]', $patientResourceId, '[''&quot;].*?\}')"/>
+            <xsl:analyze-string select="$patientTokenMap" regex="{$regex}" flags="s">
+                <xsl:matching-substring>
+                    <xsl:analyze-string select="regex-group(0)" regex='[&apos;&quot;]accessToken[&apos;&quot;]\s*:\s*[&apos;&quot;](.*?)[&apos;&quot;]'>
+                        <xsl:matching-substring>
+                            <xsl:value-of select="regex-group(1)"/>
+                        </xsl:matching-substring>
+                    </xsl:analyze-string>
+                </xsl:matching-substring>
+            </xsl:analyze-string>
+        </xsl:variable>
+
+        <xsl:choose>
+            <xsl:when test="count($patientToken) = 0">
+                <xsl:message terminate="yes" select="concat('Couldn''t find access token for Patient resource ', $patientResourceId, ' in ', $tokensJsonFile)"/>
+            </xsl:when>
+            <xsl:when test="count($patientToken) &gt; 1">
+                <xsl:message terminate="yes" select="concat('Multiple matches found for Patient resource ', $patientResourceId, ' in ', $tokensJsonFile)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <nts:authToken id="{$id}" patientResourceId="{$patientResourceId}" token="{$patientToken}"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+</xsl:stylesheet>

--- a/generate/xslt/resolveAuthTokens.xsl
+++ b/generate/xslt/resolveAuthTokens.xsl
@@ -10,7 +10,7 @@
          is a structure imposed by Touchstone for mocking token based authorization. -->
     
     <!-- The (file) URL to the JSON file matching Patient resource id's to tokens used in authorization headers. -->
-    <xsl:param name="tokensJsonFile"/>
+    <xsl:param name="tokensJsonFile" required="no"/>
 
     <!-- Load the JSON file as flat text in the patientTokenMap variable. It is assumed that the XSLT processor defers
          this operation unless/until it is actually needed. -->
@@ -24,6 +24,10 @@
     <xsl:function name="nts:resolveAuthToken" as="element(nts:authToken)?">
         <xsl:param name="patientResourceId" as="xs:string"/>
         <xsl:param name="id" as="xs:string"/>
+
+        <xsl:if test="not($tokensJsonFile)">
+            <xsl:message terminate="yes">You're trying to resolve a token based on a Patient resource id, but didn't pass in a file containing the tokens using the tokensJsonFile parameter.</xsl:message>
+        </xsl:if>
         
         <!-- Try to find the "accessToken" key associated with "resourceId": patientId in the tokens JSON file.
              This is done in two steps: first the block with the relevant resourceId is identified, and then the


### PR DESCRIPTION
Still draft (and documentation missing), but I think I found a decent way of how this feature could work. It involves two parts (like it does at the moment):
- First you declare the Patient resource id that the script is connected to using `<nts:authToken patientResourceId="blablabla"/>`
- And then you can use `<nts:authHeader/>` to expand this to a full authorization header.

How this is done depends on the scenario. For client scripts, the header will be a hardcoded value. For server scripts, a TestScript variable will be created with a default value read from the file, and this TestScript variable will be used in the header.

There is an additional feature to define multiple tokens and headers, which then should be matched using an id. I'm not sure if we're ever going to need it, but at least it's a way to control the TestScript variable.

Something I didn't realize is that the token files are also used for the load script. I'm not sure yet how this should be solved.

Proof of concept: https://github.com/Nictiz/Nictiz-testscripts/pull/111