### PR TITLE
Fix Unix/macOS compatibility without breaking Windows

### DIFF
--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -512,6 +512,9 @@
                                         <path path="${nts.file.reldir}"/>
                                         <map from="${nts.file.reldir.root}" to=""/>
                                         <map from="c:${nts.file.reldir.root}" to=""/>
+                                        <map from="h:${nts.file.reldir.root}" to=""/>
+                                        <map from="y:${nts.file.reldir.root}" to=""/>
+                                        <map from="z:${nts.file.reldir.root}" to=""/>
                                     </pathconvert>
                                     
                                     <if>
@@ -540,6 +543,9 @@
                                                         <path location="/@{target.dir}"/>
                                                         <map from="${nts.file.reldir.root}-" to=""/>
                                                         <map from="c:${nts.file.reldir.root}-" to=""/>
+                                                        <map from="h:${nts.file.reldir.root}" to=""/>
+                                                        <map from="y:${nts.file.reldir.root}" to=""/>
+                                                        <map from="z:${nts.file.reldir.root}-" to=""/>
                                                     </pathconvert>
                                                     <transform-NTS-file 
                                                         nts.file="@{nts.file}"


### PR DESCRIPTION
build.xml now works when run from H, Y or Z drives too (a Windows VM running the software from a shared drive will likely not run from C:). 

Prevents errors like this:
```Z:\Development\GitHub\Nictiz\Nictiz-testscripts\lib\Nictiz-tooling-testscripts\generate\2.7.0\ant\build.xml:195: Z:\Development\GitHub\Nictiz\Nictiz-testscripts\lib\Nictiz-tooling-testscripts\generate\2.7.0\ant\build.xml:195: Unable to create directory: Z:\Development\GitHub\Nictiz\Nictiz-testscripts\dev\FHIR3-0-2-BgZ-MSZ-1-2\Cert\Serving-XIS-CheckContentZ:\Serving-XIS```

resolveAuthTokens.xsl now will try to read the `$patientTokenMap` as-is, but when that fails, will also try after stripping `file:/*` from the path. On macOS/Unix you need file:/// instead of just file:// but you may also just work without the scheme.

Windows `file://C:/Git/...`
Unix `file:///Git/...` or `/Git/...`

