### PR TITLE
CLI-86: output targets as roles instead of variants. 

### DIFF
--- a/generate/README.md
+++ b/generate/README.md
@@ -475,25 +475,22 @@ A distinction can be made between regular TestScript-set properties and the prop
 
 ### Regular TestScript properties
 
-| Conformancelab property | input                                                                         | required? | notes                                                                                           |
-| ----------------------- | ----------------------------------------------------------------------------- | --------- |------------------------------------------------------------------------------------------------ |
-| `fhirVersion`           | `src-properties.json`, path `$.fhirVersion`                                   | x         | Defaults to ANT property `fhir.version`                                                         |
-| `goal`                  | `src-properties.json`, path `$.goal`                                          | x         | Defaults to ANT property `goal`                                                                 |
-| `informationStandard`   | `src-properties.json`, path `$.informationStandard`                           | x         | Defaults to ANT property `informationStandard`                                                  |
-| `usecase`               | `src-properties.json`, path `$.usecase`                                       | x         | Defaults to ANT property `usecase`                                                              |
-| `category`              | `src-properties.json`, path `$.category`                                      |           |                                                                                                 |
-| `subcategory`           | `src-properties.json`, path `$.subcategory`                                   |           |                                                                                                 |
-| `role`                  |                                                                               | x         |                                                                                                 |
-| - `name`                | `src-properties.json`, path `$.role.name`                                     | x         |                                                                                                 |
-| - `description`         | `src-properties.json`, path `$.role.description`                              |           |                                                                                                 |
-| `variant`               |                                                                               |           |                                                                                                 |
-| - `name`                | Build _target_ in `targets.additional`                                        | (x)       |                                                                                                 |
-| - `description`         | ANT property `target.description`._target_                                    |           | e.g. `target.description.XIS-Server-Nictiz-only = For Nictiz only`                              |
-| `adminOnly`             | `src-properties.json`, path `$.adminOnly` OR ANT property `targets.adminOnly` |           | Use `targets.adminOnly = XIS-Server-Nictiz-only` to set `adminOnly` for this specific target    |
-| `fhirPackage`           |                                                                               |           |                                                                                                 |
-| - `name`                | ANT property `packages`                                                       |           | A comma separated list of package canonicals, which is converted to an array including versions |
-| - `version`             | ANT property `package.`_canonical_                                            |           | e.g. `package.nictiz.stu3.zib2017 = 2.2.3`                                                      |
-| `serverAlias`           | `src-properties.json`, path `$.serverAlias`                                   | x         | Defaults to ANT property `serverAlias`                                                          |
+| Conformancelab property | input                                                                             | required? | notes                                                                                           |
+| ----------------------- | --------------------------------------------------------------------------------- | --------- |------------------------------------------------------------------------------------------------ |
+| `fhirVersion`           | `src-properties.json`, path `$.fhirVersion`                                       | x         | Defaults to ANT property `fhir.version`                                                         |
+| `goal`                  | `src-properties.json`, path `$.goal`                                              | x         | Defaults to ANT property `goal`                                                                 |
+| `informationStandard`   | `src-properties.json`, path `$.informationStandard`                               | x         | Defaults to ANT property `informationStandard`                                                  |
+| `usecase`               | `src-properties.json`, path `$.usecase`                                           | x         | Defaults to ANT property `usecase`                                                              |
+| `category`              | `src-properties.json`, path `$.category`                                          |           |                                                                                                 |
+| `subcategory`           | `src-properties.json`, path `$.subcategory`                                       |           |                                                                                                 |
+| `role`                  |                                                                                   | x         |                                                                                                 |
+| - `name`                | `src-properties.json`, path `$.role.name` or `$.role-[target].name`               | x         |                                                                                                 |
+| - `description`         | `src-properties.json`, path `$.role.description` or `$.role-[target].description` |           |                                                                                                 |
+| `adminOnly`             | `src-properties.json`, path `$.adminOnly` OR ANT property `targets.adminOnly`     |           | Use `targets.adminOnly = XIS-Server-Nictiz-only` to set `adminOnly` for this specific target    |
+| `fhirPackage`           |                                                                                   |           |                                                                                                 |
+| - `name`                | ANT property `packages`                                                           |           | A comma separated list of package canonicals, which is converted to an array including versions |
+| - `version`             | ANT property `package.`_canonical_                                                |           | e.g. `package.nictiz.stu3.zib2017 = 2.2.3`                                                      |
+| `serverAlias`           | `src-properties.json`, path `$.serverAlias`                                       | x         | Defaults to ANT property `serverAlias`                                                          |
 
 ### Loadresources properties
 
@@ -520,12 +517,11 @@ The `goal` parameter in the Conformancelab property file defines the goal the se
 ## Role, category and subcategory
 Conformancelab needs to know who the scripts are for. This is defined by the `role` property. In NTS projects, the scripts for a certain role are organized using folders within the root folder, e.g. "XIS-Server", "Sending-System", etc. To provide a description for a role, the `role.description` property is used.
 
-Further categorization and/or subdivision in the Conformancelab UI can be added by using the `category` and `subcategory` properties.
-
-## Variants / additional targets
-"Variants" in Conformancelab parlance are what NTS calls "Additional targets". Additional targets are places in a separate NTS folder name suffixed `-[target]`. If this tool encounters a build target, it will set the `variant.name` parameter for the resulting property file(s).
+What NTS calls "Additional targets" are outputted as separate roles. Additional targets are placed in a separate NTS folder name suffixed `-[target]`. If this tool encounters a build target, it will look for `role-[target].name` and `role-[target].description in `src-properties` to determine how the additional target should be shown in Conformancelab.
 
 To provide a description, set the ANT property `target.description.`_target_.
+
+Further categorization and/or subdivision in the Conformancelab UI can be added by using the `category` and `subcategory` properties.
 
 ## Fhir packages
 For profile validation, Conformancelab needs to know which FHIR packages to use. This is done using the ANT property `packages`, which is a comma separated list of package canonicals.[^2]

--- a/generate/ant/build.xml
+++ b/generate/ant/build.xml
@@ -232,22 +232,6 @@
     <target name="prepare-conformancelab-input">       
         <!-- Prepare some properties for generating CL-properties-files -->
         
-        <!-- Somewhat involved approach to create the 'targetDescriptions' input parameter for the XSLT conversion; a
-             single string containing a comma-separated list of '[target]=[description]' pairs. -->
-        <pathconvert property="target.descriptions.raw" pathsep=",">
-            <propertyset>
-                <propertyref prefix="target.description."/>
-                <mapper type="regexp" from="target\.description\.(.*)"
-                        to="\1=${target.description.\1}"/>
-            </propertyset>
-        </pathconvert>
-        <loadresource property="target.descriptions">
-            <propertyresource name="target.descriptions.raw"/>
-            <filterchain>
-                <expandproperties/>
-            </filterchain>
-        </loadresource>
-        
         <!-- Default to empty string -->
         <property name="targets.adminOnly" value=""/>
         
@@ -428,7 +412,7 @@
         </sequential>
     </macrodef>
     
-    <macrodef name="conformancelab-properties" description="Copy Conformancelab properties from src to output. If target is not '#default', add the target to the variant property">
+    <macrodef name="conformancelab-properties" description="Copy Conformancelab properties from src to output. If target is not '#default', add the target name and description to the role property">
         <attribute name="target" default="#default" description="The name of the target to build; choose '#default' to build the default target."/>
         <attribute name="template" default="createPropertiesInTargetFolder" description="Name of the XSLT template used to build the properties file"/>
         
@@ -444,7 +428,6 @@
                 <arg value="fhirVersion=${fhir.version}"/>
                 <arg value="informationStandard=${informationStandard}"/>
                 <arg value="usecase=${usecase}"/>
-                <arg value="targetDescriptions=${target.descriptions}"/>
                 <arg value="adminOnlyTargets=${targets.adminOnly}"/>
                 <arg value="packages=${packages}"/>
                 <arg value="packageVersions=${packages.versions}"/>
@@ -509,7 +492,7 @@
                                 references.file="${references.file}"/>
                             <collect-references references.file="${references.file}"/>
                             
-                            <!-- Check if a Conformancelab src-properties-file is present in the target.dir, copy it to the output dir and, if applicable, add the target to the variant property -->
+                            <!-- Check if a Conformancelab src-properties-file is present in the target.dir, copy it to the output dir and, if applicable, add the target name and description to the role property -->
                             <conformancelab-properties target="@{target.dir}"/>
                         </sequential>
                     </for>

--- a/generate/xslt/conformancelabProperties.xsl
+++ b/generate/xslt/conformancelabProperties.xsl
@@ -28,11 +28,6 @@
     <!-- The "usecase" according to the Conformancelab spec. -->
     <xsl:param name="usecase" as="xs:string"/>
     
-    <!-- A list matching targets to their descriptions. This list is formatted as a single comma-separated string with
-         "target=description" entries. The targets are the full folder names, and the descriptions may contain 
-         unescaped comma's. -->
-    <xsl:param name="targetDescriptions"/>
-    
     <!-- All targets part of this build -->
     <xsl:param name="targets"/>
     
@@ -132,10 +127,20 @@
                             </xsl:call-template>
                         </string>
                         
-                        <xsl:variable name="srcPropertiesRoleName" select="$srcProperties?role?name"/>
-                        <xsl:variable name="srcPropertiesRoleDescription" select="$srcProperties?role?description"/>
+                        <xsl:variable name="roleKey">
+                            <xsl:choose>
+                                <xsl:when test="$target != '#default'">
+                                    <xsl:value-of select="concat('role-',$target)"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:text>role</xsl:text>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:variable>
+                        <xsl:variable name="srcPropertiesRoleName" select="$srcProperties?($roleKey)?name"/>
+                        <xsl:variable name="srcPropertiesRoleDescription" select="$srcProperties?($roleKey)?description"/>
                         <xsl:if test="empty($srcPropertiesRoleName)">
-                            <xsl:message terminate="yes" select="concat('No ''role.name'' property found in ''', $nts.file.dir.properties?reldir, '/src-properties.json''')"/>
+                            <xsl:message terminate="yes" select="concat('No ''', $roleKey, '.name'' property found in ''', $nts.file.dir.properties?reldir, '/src-properties.json''')"/>
                         </xsl:if>
                         <map key="role">
                             <string key="name">
@@ -159,39 +164,6 @@
                             <string key="subcategory">
                                 <xsl:value-of select="$theSubcategory"/>
                             </string>
-                        </xsl:if>
-                        
-                        <!-- Possible scenarios:
-                        - Target is #default and $srcPropertiesVariantName is empty - do nothing
-                        - Target is not #default and $srcPropertiesVariantName is empty - add target as variant
-                        -->
-                        <xsl:if test="not($target = '#default')">
-                            <!--
-                                 The $targetDescriptions string is formatted as a single string with target=description
-                                 pairs, separated by comma's. The descriptions are literaly what's in the ant properties
-                                 file, no escaping, and so it might contain comma's and we can't just split on comma's.
-                                 So the surest way to fish out the description is to use a regex where we search for
-                                 'our target=' up until the start of the next pair (or the end of the string). The
-                                 start of the next pair always begins by a comma and one of the other targets, so that's our clue.
-                            -->
-                            <xsl:variable name="pattern" select="concat('.*', $target.dir, '=(.*?)($|,(', replace($targets,',','|'), '))')"/>
-                            <xsl:variable name="description">
-                                <xsl:analyze-string select="$targetDescriptions" regex="{$pattern}">
-                                    <xsl:matching-substring>
-                                        <xsl:value-of select="regex-group(1)"/>
-                                    </xsl:matching-substring>
-                                </xsl:analyze-string>
-                            </xsl:variable>
-                            <map key="variant">
-                                <string key="name">
-                                    <xsl:value-of select="$target"/>
-                                </string>
-                                <xsl:if test="string-length($description) gt 0">
-                                    <string key="description">
-                                        <xsl:value-of select="$description"/>
-                                    </string>
-                                </xsl:if>
-                            </map>
                         </xsl:if>
                         
                         <xsl:variable name="srcPropertiesAdminOnly" select="$srcProperties?adminOnly"/>


### PR DESCRIPTION
Move setting target rol name and description to src-properties